### PR TITLE
[#22] 반응형 Breakpoint 및 민트 색상 팔레트 추가

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,3 +1,20 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer base {
+  @import url('https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable.min.css');
+
+  html {
+    font-family: 'Pretendard Variable', system-ui, sans-serif;
+  }
+}
+
+/* Custom CSS */
+@layer components {
+  .item-center {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  }
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -44,6 +44,10 @@ export default {
       boxShadow: {
         base: '0 25px 50px -12px rgba(0, 0, 0, 0.25)',
       },
+      screens: {
+        mobile: '375px',
+        tablet: '744px',
+      },
     },
   },
   plugins: [],

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -8,9 +8,41 @@ export default {
   ],
   theme: {
     extend: {
+      fontFamily: {
+        sans: ['Pretendard', 'sans-serif'],
+      },
+      fontSize: {
+        xs: ['12px', '16px'],
+        sm: ['14px', '20px'],
+        base: ['16px', '24px'],
+        lg: ['18px', '28px'],
+        xl: ['20px', '28px'],
+        '2xl': ['24px', '32px'],
+        '3xl': ['30px', '36px'],
+      },
+      fontWeight: {
+        light: '300',
+        normal: '400',
+        medium: '500',
+        semibold: '600',
+        bold: '700',
+      },
       colors: {
-        background: 'var(--background)',
-        foreground: 'var(--foreground)',
+        primary: {
+          light: '#ffffff',
+          default: '#ffffff',
+          dark: '#ffffff',
+        },
+        secondary: {
+          light: '#000000',
+          default: '#000000',
+          dark: '#000000',
+        },
+        success: '#3B82F6',
+        warning: '#B91C1C',
+      },
+      boxShadow: {
+        base: '0 25px 50px -12px rgba(0, 0, 0, 0.25)',
       },
     },
   },


### PR DESCRIPTION
<!--제목 템플릿-->
<!--[#1] 프로젝트 세팅 v1.0.0-->

# 📝작업 내용
- 반응형 모바일과 테블릿 Breakpoint 추가하였습니다.
- fontSize, fontWeight는 Tailwind CSS 기본값과 동일하므로 제거
- 디자인 시스템: 민트 색상 팔레트 추가 (mint-50 ~ mint-950)
- body에 기본 텍스트 색상을 text-slate-800으로 설정

# 사용 방법
- 추가된 반응형 사이즈 적용: mobile:p-0 또는 tablet:m-0로 적용해주세요.
- 민트 팔레트: (mint-50 ~ mint-950)

# ✨PR Point
Tailwind CSS에서 기본 제공하는 설정과 동일한 부분은 추가하지 않았습니다.