### PR TITLE
[#32] 공통 Button 컴포넌트

### DIFF
--- a/src/app/ui/common/Button.tsx
+++ b/src/app/ui/common/Button.tsx
@@ -1,0 +1,71 @@
+import { ComponentPropsWithoutRef } from 'react';
+import { twMerge } from 'tailwind-merge';
+
+/**
+ * 공통 버튼 컴포넌트입니다.
+ * @param {string} size - 버튼 크기. 'small', 'middle', 'large' 중 하나를 선택합니다.
+ * @param {string} variant - 버튼 스타일. 'solid' 또는 'outlined' 중 하나를 선택합니다.
+ * @param {boolean} rounded - 버튼의 모서리를 둥글게 처리할지 여부. true면 완전 둥근 버튼이 됩니다.
+ * @param {boolean} fullWidth - 버튼의 너비를 부모 요소의 100%로 설정할지 여부. true면 버튼이 전체 너비를 차지합니다.
+ * @param {string} className - 사용자 정의 Tailwind CSS 클래스를 추가할 수 있습니다.
+ * @param {boolean} disabled - 버튼 비활성화 여부.
+ * @param {Function} onClick - 버튼 클릭 시 호출할 함수.
+ * @param {React.ReactNode} children - 버튼 내부에 렌더링될 콘텐츠.
+ */
+
+interface IButtonProps extends ComponentPropsWithoutRef<'button'> {
+  size?: 'small' | 'middle' | 'large';
+  variant?: 'solid' | 'outlined';
+  rounded?: boolean;
+  fullWidth?: boolean;
+  className?: string;
+}
+
+export default function Button(props: IButtonProps) {
+  const {
+    size = 'small',
+    variant = 'solid',
+    rounded = false,
+    fullWidth = false,
+    className,
+    children,
+    disabled,
+    onClick,
+    ...rest
+  } = props;
+
+  const baseStyles =
+    'flex items-center justify-center gap-2.5 rounded-xl border border-primary font-semibold';
+
+  const sizeStyles = {
+    small: 'h-9 w-20 py-2 text-sm leading-tight',
+    middle: 'h-11 w-36 py-3 text-sm leading-tight',
+    large: 'h-12 w-72 py-3 text-base leading-normal',
+  };
+
+  const variantStyles = {
+    solid:
+      'bg-primary text-white hover:border-mint-700 hover:bg-mint-700 active:border-mint-800 active:bg-mint-800 disabled:border-slate-400 disabled:bg-slate-400',
+    outlined:
+      'bg-white text-primary hover:border-mint-700 hover:text-mint-700 active:border-mint-800 active:text-mint-800 disabled:border-slate-400 disabled:text-slate-400',
+  };
+
+  return (
+    <button
+      className={twMerge(
+        baseStyles,
+        sizeStyles[size],
+        variantStyles[variant],
+        rounded && 'rounded-full',
+        fullWidth && 'w-full',
+        className,
+      )}
+      aria-disabled={disabled}
+      disabled={disabled}
+      onClick={onClick}
+      {...rest}
+    >
+      {children}
+    </button>
+  );
+}


### PR DESCRIPTION
<!--제목 템플릿-->
<!--[#1] 프로젝트 세팅 v1.0.0-->

# 📝작업 내용
공통 버튼 컴포넌트 구현했습니다.
- 버튼 크기(size): 'small', 'middle', 'large' 중 선택 가능
- 버튼 스타일(variant): 'solid', 'outlined' 중 선택 가능
- 둥근 모서리(rounded): true 설정 시 완전 둥근 버튼 처리
- 전체 너비(fullWidth): 부모 요소의 100% 너비로 설정 가능
- 사용자 정의 클래스(className): Tailwind CSS 커스터마이징 지원
- 비활성화(disabled): 버튼 비활성화 상태 처리
- 클릭 이벤트(onClick): 버튼 클릭 시 호출될 함수 전달 가능

# 📷스크린샷(필요 시)
![image](https://github.com/user-attachments/assets/d8e41932-7618-46a9-9e69-7acdddf57840)

# 사용 방법
```
 <Button size="small" variant="outlined" rounded={true}>
```
# ✨PR Point
버튼 스타일, 크기, 둥근 버튼 여부, width: 100% 설정을 할 수 있도록 하며, 필요에 따라 추가적인 커스텀 스타일 적용할 수 있도록 하였습니다. button 태그에서 제공하는 기본 속성들을 props로 내려받을 수 있고 많이 사용하는 disabled, onClick만 명시해놨습니다.
