### PR TITLE
[#25] Popup 컴포넌트 구현

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next';
 import './globals.css';
 import QueryProvider from './Provider/QueryProvider';
 import { SpeedInsights } from '@vercel/speed-insights/next';
+import Popup from './ui/common/Popup';
 
 export const metadata: Metadata = {
   title: 'Create Next App',
@@ -17,6 +18,7 @@ export default function RootLayout({
     <QueryProvider>
       <html lang="en">
         <body>
+          <Popup />
           {children}
           <SpeedInsights />
         </body>

--- a/src/app/store/popup.store.ts
+++ b/src/app/store/popup.store.ts
@@ -1,19 +1,20 @@
 import { create } from 'zustand';
 
-interface IShowPopupArguments {
+interface IShowPopupParameter {
   popupText: string;
   showCancelButton: boolean;
   confirmButtonText: string;
   onConfirm?: () => void;
   onCancel?: () => void;
 }
-interface IPopupProps extends IShowPopupArguments {
+
+interface IPopup extends IShowPopupParameter {
   isOpen: boolean;
-  showPopup: (args: IShowPopupArguments) => void;
+  showPopup: (params: IShowPopupParameter) => void;
   closePopup: () => void;
 }
 
-export const usePopupStore = create<IPopupProps>((set) => ({
+export const usePopupStore = create<IPopup>((set) => ({
   isOpen: false,
   popupText: '',
   showCancelButton: true,

--- a/src/app/store/popup.store.ts
+++ b/src/app/store/popup.store.ts
@@ -1,0 +1,49 @@
+import { create } from 'zustand';
+
+interface IPopupProps {
+  isOpen: boolean;
+  popupText: string[];
+  showCancelButton: boolean;
+  confirmButtonText: string;
+  onConfirm?: () => void;
+  onCancel?: () => void;
+  showPopup: (
+    popupText: string[],
+    showCancelButton: boolean,
+    confirmButtonText: string,
+    onConfirm?: () => void,
+    onCancel?: () => void,
+  ) => void;
+  closePopup: () => void;
+}
+
+export const usePopupStore = create<IPopupProps>((set) => ({
+  isOpen: false,
+  popupText: [],
+  showCancelButton: true,
+  confirmButtonText: '확인',
+  onConfirm: undefined,
+  onCancel: undefined,
+  showPopup: (
+    popupText,
+    showCancelButton,
+    confirmButtonText,
+    onConfirm,
+    onCancel,
+  ) =>
+    set({
+      isOpen: true,
+      popupText,
+      showCancelButton,
+      confirmButtonText,
+      onConfirm,
+      onCancel,
+    }),
+  closePopup: () =>
+    set({
+      isOpen: false,
+      popupText: [],
+      onConfirm: undefined,
+      onCancel: undefined,
+    }),
+}));

--- a/src/app/store/popup.store.ts
+++ b/src/app/store/popup.store.ts
@@ -1,20 +1,20 @@
 import { create } from 'zustand';
 
 interface IPopupProps {
-  isOpen: boolean;
-  popupText: string[];
-  showCancelButton: boolean;
-  confirmButtonText: string;
-  onConfirm?: () => void;
-  onCancel?: () => void;
+  isOpen: boolean; // 팝업 제어 boolean
+  popupText: string[]; // 팝업에 들어 갈 text 배열, 띄워쓰기 단위로 배열에 담아 보내면 보내시면 됩니다.
+  showCancelButton: boolean; // cancel 버튼 출력 유무 boolean
+  confirmButtonText: string; // confirm 역할을 하는 버튼에 들어가는 text
+  onConfirm?: () => void; // confirm 버튼 클릭 시 실행 할 함수
+  onCancel?: () => void; // cancel 버튼 클릭 시 실행 할 함수
   showPopup: (
     popupText: string[],
     showCancelButton: boolean,
     confirmButtonText: string,
     onConfirm?: () => void,
     onCancel?: () => void,
-  ) => void;
-  closePopup: () => void;
+  ) => void; // 팝업 열기 함수, 팝업에 들어 갈 정보를 인자로 넘겨줍니다.
+  closePopup: () => void; // 팝업 닫기 함수
 }
 
 export const usePopupStore = create<IPopupProps>((set) => ({

--- a/src/app/store/popup.store.ts
+++ b/src/app/store/popup.store.ts
@@ -1,19 +1,15 @@
 import { create } from 'zustand';
 
-interface IPopupProps {
-  isOpen: boolean;
+interface IShowPopupArguments {
   popupText: string;
   showCancelButton: boolean;
   confirmButtonText: string;
   onConfirm?: () => void;
   onCancel?: () => void;
-  showPopup: (options: {
-    popupText: string;
-    showCancelButton: boolean;
-    confirmButtonText: string;
-    onConfirm?: () => void;
-    onCancel?: () => void;
-  }) => void;
+}
+interface IPopupProps extends IShowPopupArguments {
+  isOpen: boolean;
+  showPopup: (args: IShowPopupArguments) => void;
   closePopup: () => void;
 }
 

--- a/src/app/store/popup.store.ts
+++ b/src/app/store/popup.store.ts
@@ -2,13 +2,13 @@ import { create } from 'zustand';
 
 interface IPopupProps {
   isOpen: boolean; // 팝업 제어 boolean
-  popupText: string[]; // 팝업에 들어 갈 text 배열, 띄워쓰기 단위로 배열에 담아 보내면 보내시면 됩니다.
+  popupText: string; // 팝업에 들어 갈 text
   showCancelButton: boolean; // cancel 버튼 출력 유무 boolean
   confirmButtonText: string; // confirm 역할을 하는 버튼에 들어가는 text
   onConfirm?: () => void; // confirm 버튼 클릭 시 실행 할 함수
   onCancel?: () => void; // cancel 버튼 클릭 시 실행 할 함수
   showPopup: (
-    popupText: string[],
+    popupText: string,
     showCancelButton: boolean,
     confirmButtonText: string,
     onConfirm?: () => void,
@@ -19,7 +19,7 @@ interface IPopupProps {
 
 export const usePopupStore = create<IPopupProps>((set) => ({
   isOpen: false,
-  popupText: [],
+  popupText: '',
   showCancelButton: true,
   confirmButtonText: '확인',
   onConfirm: undefined,
@@ -42,7 +42,7 @@ export const usePopupStore = create<IPopupProps>((set) => ({
   closePopup: () =>
     set({
       isOpen: false,
-      popupText: [],
+      popupText: '',
       onConfirm: undefined,
       onCancel: undefined,
     }),

--- a/src/app/store/popup.store.ts
+++ b/src/app/store/popup.store.ts
@@ -1,20 +1,20 @@
 import { create } from 'zustand';
 
 interface IPopupProps {
-  isOpen: boolean; // 팝업 제어 boolean
-  popupText: string; // 팝업에 들어 갈 text
-  showCancelButton: boolean; // cancel 버튼 출력 유무 boolean
-  confirmButtonText: string; // confirm 역할을 하는 버튼에 들어가는 text
-  onConfirm?: () => void; // confirm 버튼 클릭 시 실행 할 함수
-  onCancel?: () => void; // cancel 버튼 클릭 시 실행 할 함수
-  showPopup: (
-    popupText: string,
-    showCancelButton: boolean,
-    confirmButtonText: string,
-    onConfirm?: () => void,
-    onCancel?: () => void,
-  ) => void; // 팝업 열기 함수, 팝업에 들어 갈 정보를 인자로 넘겨줍니다.
-  closePopup: () => void; // 팝업 닫기 함수
+  isOpen: boolean;
+  popupText: string;
+  showCancelButton: boolean;
+  confirmButtonText: string;
+  onConfirm?: () => void;
+  onCancel?: () => void;
+  showPopup: (options: {
+    popupText: string;
+    showCancelButton: boolean;
+    confirmButtonText: string;
+    onConfirm?: () => void;
+    onCancel?: () => void;
+  }) => void;
+  closePopup: () => void;
 }
 
 export const usePopupStore = create<IPopupProps>((set) => ({
@@ -24,13 +24,13 @@ export const usePopupStore = create<IPopupProps>((set) => ({
   confirmButtonText: '확인',
   onConfirm: undefined,
   onCancel: undefined,
-  showPopup: (
+  showPopup: ({
     popupText,
     showCancelButton,
     confirmButtonText,
     onConfirm,
     onCancel,
-  ) =>
+  }) =>
     set({
       isOpen: true,
       popupText,

--- a/src/app/ui/common/Popup.tsx
+++ b/src/app/ui/common/Popup.tsx
@@ -108,17 +108,15 @@ export default function Popup() {
           <footer className="mx-auto my-0 flex justify-center gap-2">
             {showCancelButton && (
               <Button
+                size="large"
                 variant="outlined"
-                className="h-[48px] w-[120px] px-[46px] py-[12px] font-semibold"
+                className="w-[120px]"
                 onClick={handleCancel}
               >
                 취소
               </Button>
             )}
-            <Button
-              className="h-[48px] w-[120px] px-[46px] py-[12px] font-semibold"
-              onClick={handleConfirm}
-            >
+            <Button size="large" className="w-[120px]" onClick={handleConfirm}>
               {confirmButtonText}
             </Button>
           </footer>

--- a/src/app/ui/common/Popup.tsx
+++ b/src/app/ui/common/Popup.tsx
@@ -1,0 +1,90 @@
+/* eslint-disable jsx-a11y/no-static-element-interactions */
+/* eslint-disable jsx-a11y/click-events-have-key-events */
+/* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
+'use client';
+
+import { usePopupStore } from '../../store/popup.store';
+import Button from './Button';
+
+export default function Popup() {
+  const {
+    isOpen,
+    popupText,
+    showCancelButton,
+    confirmButtonText,
+    onConfirm,
+    onCancel,
+    closePopup,
+  } = usePopupStore();
+
+  const handleConfirm = () => {
+    if (onConfirm) {
+      onConfirm();
+    }
+    closePopup();
+  };
+
+  const handleCancel = () => {
+    if (onCancel) {
+      onCancel();
+    }
+    closePopup();
+  };
+
+  const handleOverlayClick = () => {
+    closePopup();
+  };
+
+  if (!isOpen) {
+    return null;
+  }
+
+  return (
+    <div
+      className="absolute h-[100vh] w-full cursor-pointer bg-black bg-opacity-50"
+      onClick={handleOverlayClick}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="popup-text"
+    >
+      <div
+        className="z-2 absolute left-1/2 top-1/2 mx-auto my-0 w-[300px] -translate-x-1/2 -translate-y-1/2 transform cursor-default rounded-lg bg-white tablet:w-[450px]"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="box-border flex flex-col gap-6 p-6">
+          {!showCancelButton && (
+            <section className="text-right">
+              {/* TODO: X 아이콘 삽입하기 */}
+              <button onClick={handleCancel}>X</button>{' '}
+              {/* 아이콘 들어올 자리 */}
+            </section>
+          )}
+          <main className="mx-auto my-0 text-center">
+            {popupText.map((text, index) => (
+              <p className="font-medium" key={index}>
+                {text}
+              </p>
+            ))}
+          </main>
+          <footer className="mx-auto my-0 flex justify-center gap-2">
+            {showCancelButton && (
+              <Button
+                variant="outlined"
+                className="h-[48px] w-[120px] px-[46px] py-[12px] font-semibold"
+                onClick={handleCancel}
+              >
+                취소
+              </Button>
+            )}
+            <Button
+              className="h-[48px] w-[120px] px-[46px] py-[12px] font-semibold"
+              onClick={handleConfirm}
+            >
+              {confirmButtonText}
+            </Button>
+          </footer>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/ui/common/Popup.tsx
+++ b/src/app/ui/common/Popup.tsx
@@ -3,6 +3,7 @@
 /* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
 'use client';
 
+import { useEffect, useRef } from 'react';
 import { usePopupStore } from '../../store/popup.store';
 import Button from './Button';
 
@@ -16,6 +17,8 @@ export default function Popup() {
     onCancel,
     closePopup,
   } = usePopupStore();
+
+  const popupRef = useRef<HTMLDivElement>(null); // 팝업 전체를 참조
 
   const handleConfirm = () => {
     if (onConfirm) {
@@ -31,9 +34,27 @@ export default function Popup() {
     closePopup();
   };
 
-  const handleOverlayClick = () => {
-    closePopup();
+  const handleOverlayClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (e.target === e.currentTarget) {
+      closePopup();
+    }
   };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (e.key === 'Escape') {
+      closePopup(); // ESC 키로 팝업 닫기
+    }
+    if (e.key === 'Enter') {
+      handleConfirm(); // Enter 키로 확인 버튼 동작
+    }
+  };
+
+  // 팝업이 열릴 때 포커스를 이동
+  useEffect(() => {
+    if (isOpen && popupRef.current) {
+      popupRef.current.focus(); // 팝업 컨테이너에 포커스 설정
+    }
+  }, [isOpen]);
 
   if (!isOpen) {
     return null;
@@ -48,15 +69,23 @@ export default function Popup() {
       aria-labelledby="popup-text"
     >
       <div
+        ref={popupRef} // 팝업 컨테이너 참조
         className="z-2 absolute left-1/2 top-1/2 mx-auto my-0 w-[300px] -translate-x-1/2 -translate-y-1/2 transform cursor-default rounded-lg bg-white tablet:w-[450px]"
+        tabIndex={-1} // 키보드 포커스를 받을 수 있도록 설정
+        onKeyDown={handleKeyDown}
         onClick={(e) => e.stopPropagation()}
       >
         <div className="box-border flex flex-col gap-6 p-6">
           {!showCancelButton && (
             <section className="text-right">
               {/* TODO: X 아이콘 삽입하기 */}
-              <button onClick={handleCancel}>X</button>{' '}
-              {/* 아이콘 들어올 자리 */}
+              <button
+                onClick={handleCancel}
+                aria-label="닫기"
+                className="text-xl"
+              >
+                X
+              </button>
             </section>
           )}
           <main className="mx-auto my-0 text-center">

--- a/src/app/ui/common/Popup.tsx
+++ b/src/app/ui/common/Popup.tsx
@@ -60,11 +60,7 @@ export default function Popup() {
             </section>
           )}
           <main className="mx-auto my-0 text-center">
-            {popupText.map((text, index) => (
-              <p className="font-medium" key={index}>
-                {text}
-              </p>
-            ))}
+            <p className="whitespace-pre-wrap break-words">{popupText}</p>
           </main>
           <footer className="mx-auto my-0 flex justify-center gap-2">
             {showCancelButton && (

--- a/src/app/ui/common/Popup.tsx
+++ b/src/app/ui/common/Popup.tsx
@@ -56,13 +56,27 @@ export default function Popup() {
     }
   }, [isOpen]);
 
+  // 팝업이 열렸을 때 스크롤 막기
+  useEffect(() => {
+    if (isOpen) {
+      document.body.style.overflow = 'hidden'; // 스크롤 막기
+    } else {
+      document.body.style.overflow = ''; // 스크롤 다시 활성화
+    }
+
+    // 컴포넌트 언마운트 시 스크롤 다시 활성화
+    return () => {
+      document.body.style.overflow = '';
+    };
+  }, [isOpen]);
+
   if (!isOpen) {
     return null;
   }
 
   return (
     <div
-      className="absolute h-[100vh] w-full cursor-pointer bg-black bg-opacity-50"
+      className="absolute z-[9999] h-[100vh] w-full cursor-pointer bg-black bg-opacity-50"
       onClick={handleOverlayClick}
       role="dialog"
       aria-modal="true"
@@ -70,7 +84,7 @@ export default function Popup() {
     >
       <div
         ref={popupRef} // 팝업 컨테이너 참조
-        className="z-2 absolute left-1/2 top-1/2 mx-auto my-0 w-[300px] -translate-x-1/2 -translate-y-1/2 transform cursor-default rounded-lg bg-white tablet:w-[450px]"
+        className="absolute left-1/2 top-1/2 mx-auto my-0 w-[300px] -translate-x-1/2 -translate-y-1/2 transform cursor-default rounded-lg bg-white tablet:w-[450px]"
         tabIndex={-1} // 키보드 포커스를 받을 수 있도록 설정
         onKeyDown={handleKeyDown}
         onClick={(e) => e.stopPropagation()}


### PR DESCRIPTION
<!--제목 템플릿-->
<!--[#1] 프로젝트 세팅 v1.0.0-->

# 📝작업 내용

Popup 컴포넌트를 구현했습니다.

# 📷스크린샷(필요 시)

환경에 따라 width 값이 바뀝니다

## PC, Tablet
![스크린샷 2024-12-02 오후 2 20 18](https://github.com/user-attachments/assets/e8ce1eb5-50af-4bd6-97ae-c8184cdfb8f7)
![스크린샷 2024-12-02 오후 2 19 37](https://github.com/user-attachments/assets/eb1c1a2e-99cf-484d-8078-37c8f6a5873f)

## Mobile
![스크린샷 2024-12-02 오후 2 20 08](https://github.com/user-attachments/assets/23f9547c-60bd-4ef7-8371-3ec8c30c94ad)
![스크린샷 2024-12-02 오후 2 19 45](https://github.com/user-attachments/assets/a6192896-cf71-4e2e-ac0a-b96cf80920d5)


# 사용 방법

사용하는 곳에서는 `usePopupStore()` 의 `showPopup()` 함수를 불러와 팝업에 들어 갈 데이터를 `객체 형태로` 함수의 인자로 넘겨주어 사용하시면 됩니다.

객체에는 `popupText`, `showCancelButton`, `confirmButtonText`, `onConfirm`, `onCancel` 가 들어갈 수 있습니다.

- `popupText` (필수) : 팝업에 들어 갈 문구를 의미하는 `string` 값입니다. 텍스트 내 `\n`을 기준으로 띄워쓰기가 적용됩니다.

- `showCancelButton` (필수) : cancel 역할을 하는 버튼의 출력 유무를 의미하는 `boolean` 값입니다. 

    - `true` 시 confrim, cancel 버튼 2개가 표시되고, `false` 시, confirm 버튼 1개와 우측 상단 `X` 아이콘이 표시됩니다.
    
- `confirmButtonText` (필수) : confirm 버튼에 들어갈 텍스트를 의미하는 `string` 값입니다.

- `onConfirm` (선택) : confirm 버튼 클릭 시 실행 할 함수를 받습니다. 생략 시 undefined 값으로 들어가게 됩니다.

- `onCancel` (선택) : cancel 버튼 클릭 시 실행 할 함수를 받습니다. 생략 시 undefined 값으로 들어가게 됩니다.

```javascript

'use client';

import { usePopupStore } from '../store/popup.store';

export default function Playground() {
  const { showPopup } = usePopupStore();

  const onConfirm = () => {
    alert('Confirm');
  };

  const onCancel = () => {
    alert('Cancel');
  };

  const handlePopup = () => {
    showPopup({
      popupText: '목표를 삭제하시겠어요? \n 삭제된 목표는 복구할 수 없습니다.',
      showCancelButton: true,
      confirmButtonText: '확인',
    });
  };

  const handleFalsePopup = () => {
    showPopup({
      popupText: '가입이 완료되었습니다!',
      showCancelButton: false,
      confirmButtonText: '확인',
      onConfirm,
      onCancel,
    });
  };

  return (
    <div className="h-[2000px] px-[10rem]">
      <button onClick={handlePopup}>popup</button>
      <button onClick={handleFalsePopup}>no 취소</button>
    </div>
  );
}



```

# ✨PR Point

### 1. Lint 에러 관련
팝업 창 외부를 클릭하면 팝업 창이 닫기도록 구현하기 위해 `div` 태그에 onClick 이벤트를 추가하니 웹 표준에 어긋난다는 line 에러가 발생해 `Popup.tsx` 상단에 아래와 같은 lint 에러 무시 코드를 추가했습니다.

```
/* eslint-disable jsx-a11y/no-static-element-interactions */
/* eslint-disable jsx-a11y/click-events-have-key-events */
/* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
```

```
Visible, non-interactive elements with click handlers must have at least one keyboard listener.

Non-interactive elements should not be assigned mouse or keyboard event listeners.

Visible, non-interactive elements with click handlers must have at least one keyboard listener.

Avoid non-native interactive elements. If using native HTML is not possible, add an appropriate role and support for tabbing, mouse, keyboard, and touch inputs to an interactive content element.
```
onClick 이벤트는 상호 작용을 하는 태그 (button, a 등)에만 적용해야 한다고 하는데 어떻게 해결할 수 있을까요…? GPT 돌려도 해결이 안되네요 ㅠㅠ

### 2. 코드 관련

코드 관련해서 이상한 부분이 있으면 언제든지 리뷰 남겨주세요 !! (스타일, 형태 등등)
