### PR TITLE
[#54] Popup 컴포넌트 사용법 개편 - usePopup hook 생성

### DIFF
--- a/src/hooks/usePopup.ts
+++ b/src/hooks/usePopup.ts
@@ -1,0 +1,31 @@
+import { usePopupStore } from '@store/popup.store';
+
+interface IShowPopupOptions {
+  popupText: string;
+  showCancelButton: false;
+  confirmButtonText: string;
+  onConfirm?: () => void;
+  onCancel?: () => void;
+}
+
+export const usePopup = () => {
+  const { showPopup } = usePopupStore();
+
+  const openPopup = ({
+    popupText,
+    showCancelButton,
+    confirmButtonText,
+    onConfirm,
+    onCancel,
+  }: IShowPopupOptions) => {
+    showPopup({
+      popupText,
+      showCancelButton,
+      confirmButtonText,
+      onConfirm,
+      onCancel,
+    });
+  };
+
+  return { openPopup };
+};

--- a/src/store/popup.store.ts
+++ b/src/store/popup.store.ts
@@ -1,6 +1,6 @@
 import { create } from 'zustand';
 
-interface IShowPopupParameter {
+interface IShowPopupState {
   popupText: string;
   showCancelButton: boolean;
   confirmButtonText: string;
@@ -8,13 +8,13 @@ interface IShowPopupParameter {
   onCancel?: () => void;
 }
 
-interface IPopup extends IShowPopupParameter {
+interface IPopupStore extends IShowPopupState {
   isOpen: boolean;
-  showPopup: (params: IShowPopupParameter) => void;
+  showPopup: (params: IShowPopupState) => void;
   closePopup: () => void;
 }
 
-export const usePopupStore = create<IPopup>((set) => ({
+export const popupStore = create<IPopupStore>((set) => ({
   isOpen: false,
   popupText: '',
   showCancelButton: true,

--- a/src/ui/common/Popup.tsx
+++ b/src/ui/common/Popup.tsx
@@ -3,7 +3,7 @@
 /* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
 'use client';
 
-import { usePopupStore } from '@store/popup.store';
+import { popupStore } from '@store/popup.store';
 import { useEffect, useRef } from 'react';
 import Button from './Button';
 
@@ -16,7 +16,7 @@ export default function Popup() {
     onConfirm,
     onCancel,
     closePopup,
-  } = usePopupStore();
+  } = popupStore();
 
   const popupRef = useRef<HTMLDivElement>(null); // 팝업 전체를 참조
 

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -13,14 +13,8 @@ export default {
   theme: {
     extend: {
       colors: {
-        primary: {
-          DEFAULT: 'hsl(var(--primary))',
-          foreground: 'hsl(var(--primary-foreground))',
-        },
-        secondary: {
-          DEFAULT: 'hsl(var(--secondary))',
-          foreground: 'hsl(var(--secondary-foreground))',
-        },
+        primary: '#19D1CB',
+        secondary: '#000000',
         mint: {
           '50': '#F3FCFC',
           '100': '#E6F9F9',


### PR DESCRIPTION
<!--제목 템플릿-->
<!--[#1] 프로젝트 세팅 v1.0.0-->

# 📝작업 내용

usePopup hook을 구현했습니다.

기존 방식인 `usePopupStore 에 직접 접근하여 팝업을 띄운다.`에서 개편안인 `usePopup() hook을 통해 팝업을 띄운다.` 로 사용법을 변경하였습니다. 

---

추가로 tailwind.config.ts에 primary, secondary color를 기존 color로 수정했습니다.

# 사용 방법

`popupText`, `showCancelButton`, `confirmButtonText`은 필수값, `onConfirm`, `onCancel`은 선택값입니다.
각각의 의미는 [Popup 컴포넌트 PR](https://github.com/codeit5-Team8/torip-frontend/pull/38 ) 확인 해주시면 됩니다.

```javascript

'use client';

import { usePopup } from '@hooks/usePopup';

export default function Playground() {
  const { openPopup } = usePopup();

  const onConfirm = () => {
    alert('Confirm');
  };

  const onCancel = () => {
    alert('Cancel');
  };

  const handlePopup = () => {
    openPopup({
      popupText: '목표를 삭제하시겠어요? \n 삭제된 목표는 복구할 수 없습니다.',
      showCancelButton: false,
      confirmButtonText: '확인',
      onConfirm,
      onCancel,
    });
  };

  return (
    <div className="h-[2000px] px-[10rem]">
      <button onClick={handlePopup}>popup</button>
    </div>
  );
}


```

# ✨PR Point

~~hook 구현하다가 알게된 사실인데, 저희 색상 코드가 바뀐 것 같습니다..!! hover 했을 때 민트색은 잘 뜨는 상태입니다 !~~ => 해결됐습니다 :)

![스크린샷 2024-12-04 오전 10 00 35](https://github.com/user-attachments/assets/f1fd8fe4-75a4-4b6b-9254-f907efed880f)
