### PR TITLE
[#49] Modal 컴포넌트 구현

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import './globals.css';
 import { SpeedInsights } from '@vercel/speed-insights/next';
 import QueryProvider from '@provider/QueryProvider';
 import Popup from '@ui/common/Popup';
+import Modal from '@ui/common/Modal';
 
 export const metadata: Metadata = {
   title: 'Create Next App',
@@ -18,8 +19,9 @@ export default function RootLayout({
     <QueryProvider>
       <html lang="en">
         <body>
-          {children}
           <Popup />
+          <Modal />
+          {children}
           <SpeedInsights />
         </body>
       </html>

--- a/src/hooks/useModal.ts
+++ b/src/hooks/useModal.ts
@@ -1,0 +1,19 @@
+import { modalStore } from '@store/modal.store';
+
+interface IShowModalState {
+  title: string;
+  content: React.ReactNode;
+}
+
+export const useModal = () => {
+  const { showModal, closeModal } = modalStore();
+
+  const openModal = ({ title, content }: IShowModalState) => {
+    showModal({
+      title,
+      content,
+    });
+  };
+
+  return { openModal, closeModal };
+};

--- a/src/store/modal.store.ts
+++ b/src/store/modal.store.ts
@@ -1,0 +1,30 @@
+import { create } from 'zustand';
+
+interface IModalState {
+  title: string;
+  content: React.ReactNode;
+}
+
+interface IModalStore extends IModalState {
+  isOpen: boolean;
+  showModal: (modalData: IModalState) => void;
+  closeModal: () => void;
+}
+
+export const modalStore = create<IModalStore>((set) => ({
+  isOpen: false,
+  title: '',
+  content: '',
+  showModal: (modalData: IModalState) =>
+    set({
+      isOpen: true,
+      title: modalData.title,
+      content: modalData.content,
+    }),
+  closeModal: () =>
+    set({
+      isOpen: false,
+      title: '',
+      content: '',
+    }),
+}));

--- a/src/ui/common/Modal.tsx
+++ b/src/ui/common/Modal.tsx
@@ -1,0 +1,81 @@
+/* eslint-disable jsx-a11y/no-static-element-interactions */
+/* eslint-disable jsx-a11y/click-events-have-key-events */
+/* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
+'use client';
+
+import { modalStore } from '@store/modal.store';
+import { useEffect, useRef } from 'react';
+
+export default function Modal() {
+  const { isOpen, title, content, closeModal } = modalStore();
+
+  const modalRef = useRef<HTMLDivElement>(null);
+
+  const handleCloseModal = () => {
+    // TODO: Popup 컴포넌트 띄우는 작업 필요
+    if (confirm('작성된 내용이 모두 삭제됩니다. 정말 나가시겠어요?')) {
+      closeModal();
+    }
+  };
+
+  const handleOverlayClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (e.target === e.currentTarget) {
+      closeModal();
+    }
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (e.key === 'Escape') {
+      closeModal();
+    }
+  };
+
+  useEffect(() => {
+    if (isOpen && modalRef.current) {
+      modalRef.current.focus();
+    }
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (isOpen) {
+      document.body.style.overflow = 'hidden';
+    } else {
+      document.body.style.overflow = '';
+    }
+
+    return () => {
+      document.body.style.overflow = '';
+    };
+  }, [isOpen]);
+
+  return (
+    <>
+      {isOpen && (
+        <div
+          className="tablet:absolute tablet:z-[5555] tablet:h-[100vh] tablet:w-full tablet:bg-black tablet:bg-opacity-50"
+          onClick={handleOverlayClick}
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="modal"
+        >
+          <main
+            ref={modalRef}
+            className="absolute left-1/2 top-1/2 mx-auto my-0 box-border h-[100dvh] w-[100vw] min-w-[320px] -translate-x-1/2 -translate-y-1/2 transform cursor-default overflow-auto bg-white p-6 tablet:h-[724px] tablet:w-[520px] tablet:rounded-xl"
+            tabIndex={-1}
+            onKeyDown={handleKeyDown}
+            onClick={(e) => e.stopPropagation()}
+          >
+            <article className="flex flex-col gap-[10px]">
+              <section className="flex items-center justify-between">
+                <p className="text-lg font-bold">{title}</p>
+                {/* TODO: X 아이콘 삽입 */}
+                <button onClick={handleCloseModal}>X</button>
+              </section>
+              <section className="overflow-auto">{content}</section>
+            </article>
+          </main>
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/ui/common/Popup.tsx
+++ b/src/ui/common/Popup.tsx
@@ -70,58 +70,62 @@ export default function Popup() {
     };
   }, [isOpen]);
 
-  if (!isOpen) {
-    return null;
-  }
-
   return (
-    <div
-      className="absolute z-[9999] h-[100vh] w-full bg-black bg-opacity-50"
-      onClick={handleOverlayClick}
-      role="dialog"
-      aria-modal="true"
-      aria-labelledby="popup-text"
-    >
-      <div
-        ref={popupRef} // 팝업 컨테이너 참조
-        className="absolute left-1/2 top-1/2 mx-auto my-0 w-[300px] -translate-x-1/2 -translate-y-1/2 transform cursor-default rounded-lg bg-white desktop:w-[450px]"
-        tabIndex={-1} // 키보드 포커스를 받을 수 있도록 설정
-        onKeyDown={handleKeyDown}
-        onClick={(e) => e.stopPropagation()}
-      >
-        <div className="box-border flex flex-col gap-6 p-6">
-          {!showCancelButton && (
-            <section className="text-right">
-              {/* TODO: X 아이콘 삽입하기 */}
-              <button
-                onClick={handleCancel}
-                aria-label="닫기"
-                className="text-xl"
-              >
-                X
-              </button>
-            </section>
-          )}
-          <main className="mx-auto my-0 text-center">
-            <p className="whitespace-pre-wrap break-words">{popupText}</p>
-          </main>
-          <footer className="mx-auto my-0 flex justify-center gap-2">
-            {showCancelButton && (
-              <Button
-                size="large"
-                variant="outlined"
-                className="w-[120px]"
-                onClick={handleCancel}
-              >
-                취소
-              </Button>
-            )}
-            <Button size="large" className="w-[120px]" onClick={handleConfirm}>
-              {confirmButtonText}
-            </Button>
-          </footer>
+    <>
+      {isOpen && (
+        <div
+          className="absolute z-[9999] h-[100vh] w-full bg-black bg-opacity-50"
+          onClick={handleOverlayClick}
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="popup-text"
+        >
+          <div
+            ref={popupRef} // 팝업 컨테이너 참조
+            className="absolute left-1/2 top-1/2 mx-auto my-0 w-[300px] -translate-x-1/2 -translate-y-1/2 transform cursor-default rounded-lg bg-white desktop:w-[450px]"
+            tabIndex={-1} // 키보드 포커스를 받을 수 있도록 설정
+            onKeyDown={handleKeyDown}
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="box-border flex flex-col gap-6 p-6">
+              {!showCancelButton && (
+                <section className="text-right">
+                  {/* TODO: X 아이콘 삽입하기 */}
+                  <button
+                    onClick={handleCancel}
+                    aria-label="닫기"
+                    className="text-xl"
+                  >
+                    X
+                  </button>
+                </section>
+              )}
+              <main className="mx-auto my-0 text-center">
+                <p className="whitespace-pre-wrap break-words">{popupText}</p>
+              </main>
+              <footer className="mx-auto my-0 flex justify-center gap-2">
+                {showCancelButton && (
+                  <Button
+                    size="large"
+                    variant="outlined"
+                    className="w-[120px]"
+                    onClick={handleCancel}
+                  >
+                    취소
+                  </Button>
+                )}
+                <Button
+                  size="large"
+                  className="w-[120px]"
+                  onClick={handleConfirm}
+                >
+                  {confirmButtonText}
+                </Button>
+              </footer>
+            </div>
+          </div>
         </div>
-      </div>
-    </div>
+      )}
+    </>
   );
 }


### PR DESCRIPTION
# 📝작업 내용

Modal 컴포넌트를 구현했습니다.

# 📷스크린샷(필요 시)

Desktop, Tablet => Modal 컴포넌트가 화면 중앙에 위치합니다.
Mobile => Modal 컴포넌트가 전체 페이지를 차지합니다.

- X 아이콘을 누르면 confirm 창을 거쳐 Modal을 제어할 수 있습니다. 
    - 추후 Popup 컴포넌트로 교체할 예정입니다. Popup 컴포넌트의 구조를 수정해야할 것 같아 임시로 comfirm  창을 적용했습니다.
- Desktop, Tablet 환경에서 모달 외부를 클릭하면 모달이 닫힙니다.
- ESC를 누르면 모달이 닫힙니다.
- 모달 내 confirm 버튼으로 모달을 제어할 수 있습니다. (아래 주의할 점 서술)

https://github.com/user-attachments/assets/5cc376c2-3bc1-4035-ab20-2c7bba7c29fd

# 사용 방법

- useModal hook의 `openModal` 매서드로 모달을 열 수 있습니다.
    - `title`: string 타입. Modal의 제목을 의미합니다.
    - `content` : React.ReactNode 타입. Modal안에 들어갈 내용을 의미합니다. 컴포넌트 형태로 넘기면 될 것 같습니다 :)
- 주의해야 할 점은, **Modal의 confirm 버튼 클릭 후 useModal hook의 `closeModal()` 매서드를 호출해주셔야 모달이 닫힙니다.**

```javascript

'use client';

import { useModal } from '@hooks/useModal';

export default function Playground() {
  const { openModal, closeModal } = useModal();

  // Modal의 확인 버튼 누를 때 동작 할 함수
  const handleModalConfirm = () => {
    // 확인 버튼을 눌렀을 때 실행시킬 작업들
    closeModal(); // 마지막에 useModal hook의 `closeModal()` 매서드를 호출해주셔야 모달이 닫힙니다.
  };

  const handleModal = () => {
    openModal({
      title: '할 일 생성',
      content: (
        <div>
          <div className="bg-black">컨텐츠다</div>
          <button className="bg-white" onClick={handleModalConfirm}>
            확인
          </button>
        </div>
      ),
    });
  };

  return (
    <div>
      <button onClick={handleModal}>모달 오픈</button>
    </div>
  );
}


```

# ✨PR Point

- Popup, Modal 컴포넌트 1차 구현은 마무리 되었고, 더 고려해야 할 부분이 생긴다면 버전업하여 리팩토링 하겠습니다 !!