### PR TITLE
[#110] : authoption 통한 refreshtoken rotation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "date-fns": "^4.1.0",
+        "dayjs": "^1.11.13",
         "framer-motion": "^11.15.0",
         "lucide-react": "^0.462.0",
         "next": "^14.2.18",
@@ -6811,7 +6812,6 @@
       "version": "1.11.13",
       "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.13.tgz",
       "integrity": "sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/debug": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",
+    "dayjs": "^1.11.13",
     "framer-motion": "^11.15.0",
     "lucide-react": "^0.462.0",
     "next": "^14.2.18",

--- a/src/constant/queryKeyFactory.ts
+++ b/src/constant/queryKeyFactory.ts
@@ -10,9 +10,6 @@ export const tasksQueryKeys = createQueryKeys('tasks', {
     queryKey: ['tasksList'],
     queryFn: () => getTask(props),
   }),
-});
-
-export const progressQueryKeys = createQueryKeys('progress', {
   progress: () => ({
     queryKey: ['taskProgress'],
     queryFn: () => getTaskProgress(),

--- a/src/hooks/task/useGetProgress.ts
+++ b/src/hooks/task/useGetProgress.ts
@@ -1,9 +1,9 @@
+import { tasksQueryKeys } from '@constant/queryKeyFactory';
 import { useQuery } from '@tanstack/react-query';
-import { progressQueryKeys } from '@constant/queryKeyFactory';
 
 export const useGetProgress = () => {
   return useQuery({
-    ...progressQueryKeys.progress(),
+    ...tasksQueryKeys.progress(),
     select: (data) => {
       const result = data?.result;
 

--- a/src/lib/api/service/auth.api.ts
+++ b/src/lib/api/service/auth.api.ts
@@ -21,6 +21,11 @@ export const postRefreshToken = async (data: TPostRefreshTokenRequest) => {
   const response = await post<TResponse<TTokenResponse>>(
     '/api/v1/torip/auth/refresh',
     data,
+    {
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    },
   );
   return response.data;
 };

--- a/src/lib/authOptions.ts
+++ b/src/lib/authOptions.ts
@@ -1,17 +1,24 @@
 import CredentialsProvider from 'next-auth/providers/credentials';
-import { postLogin, postRegister } from './api/service/auth.api';
 import { NextAuthOptions, Session, User } from 'next-auth';
 import { JWT } from 'next-auth/jwt';
+import dayjs from 'dayjs';
+import {
+  postLogin,
+  postRefreshToken,
+  postRegister,
+} from './api/service/auth.api';
 
 interface IMyUser extends User {
   accessToken?: string;
   refreshToken?: string;
+  expiredAt?: string;
 }
 
 export const authOptions: NextAuthOptions = {
-  secret: process.env.NEXTAUTH_SECRET, // NextAuth 비밀키
+  secret: process.env.NEXTAUTH_SECRET,
   providers: [
     CredentialsProvider({
+      // 기존 CredentialsProvider 설정 유지
       name: 'credentials',
       credentials: {
         name: {
@@ -33,6 +40,7 @@ export const authOptions: NextAuthOptions = {
       async authorize(
         credentials: Record<'name' | 'email' | 'password', string> | undefined,
       ) {
+        // 기존 authorize 함수 내용 유지
         if (!credentials) {
           throw new Error('No credentials provided.');
         }
@@ -54,7 +62,7 @@ export const authOptions: NextAuthOptions = {
             return { id: '1', name, email, ...token };
           } else {
             const error = new Error('Signup failed.');
-            (error as Error).message = message; //서버 msg 넣기
+            (error as Error).message = message;
             throw error;
           }
         }
@@ -72,9 +80,8 @@ export const authOptions: NextAuthOptions = {
         if (success) {
           return { id: '1', name, email, ...token };
         } else {
-          // 커스텀 에러 객체 생성
           const error = new Error('Login failed.');
-          (error as Error).message = message; //서버 msg 넣기
+          (error as Error).message = message;
           throw error;
         }
       },
@@ -84,24 +91,66 @@ export const authOptions: NextAuthOptions = {
     signIn: '/signin',
   },
   callbacks: {
-    async jwt({ token, user }: { token: JWT; user: IMyUser }) {
+    async jwt({ token, user }: { token: JWT; user?: IMyUser }) {
       if (user) {
         token.id = Number(user.id);
         token.email = user.email;
         token.name = user.name;
-        token.accessToken = user.accessToken as string;
-        token.refreshToken = user.refreshToken as string;
+        token.accessToken = user.accessToken;
+        token.refreshToken = user.refreshToken;
+        token.expiredAt = user.expiredAt;
       }
-      return token;
+
+      if (
+        token.expiredAt &&
+        dayjs(token.expiredAt as string).isAfter(dayjs())
+      ) {
+        return token;
+      }
+
+      const response = await postRefreshToken({
+        refreshToken: token.refreshToken as string,
+      });
+
+      if (response.success && response.result) {
+        return {
+          ...token,
+          accessToken: response.result.accessToken,
+          refreshToken: response.result.refreshToken,
+          expiredAt: response.result.expiredAt,
+        };
+      } else {
+        return {
+          id: token.id,
+          email: token.email,
+          name: token.name,
+          accessToken: undefined,
+          refreshToken: undefined,
+          expiredAt: undefined,
+        };
+      }
     },
 
     async session({ session, token }: { session: Session; token: JWT }) {
-      if (session.user) {
+      if (token.accessToken) {
         session.user.id = token.id as number;
         session.user.email = token.email as string;
         session.user.name = token.name as string;
         session.accessToken = token.accessToken as string;
         session.refreshToken = token.refreshToken as string;
+        session.expiredAt = token.expiredAt as string;
+      } else {
+        session = {
+          ...session,
+          user: {
+            id: 0,
+            name: null,
+            email: null,
+          },
+          accessToken: undefined,
+          refreshToken: undefined,
+          expiredAt: undefined,
+        };
       }
       return session;
     },

--- a/src/lib/next-auth.d.ts
+++ b/src/lib/next-auth.d.ts
@@ -12,6 +12,7 @@ declare module 'next-auth' {
     } & DefaultSession['user'];
     accessToken?: string;
     refreshToken?: string;
+    expiredAt?: string;
   }
 
   interface IUser {

--- a/src/model/auth.model.ts
+++ b/src/model/auth.model.ts
@@ -4,7 +4,7 @@ export type TPostRegisterRequest = {
   password: string;
 };
 
-export type TPostRefreshTokenRequest = string;
+export type TPostRefreshTokenRequest = { refreshToken: string };
 
 export type TPostLoginRequest = Omit<TPostRegisterRequest, 'username'>;
 

--- a/src/model/model.ts
+++ b/src/model/model.ts
@@ -8,4 +8,5 @@ export type TResponse<T> = {
 export type TTokenResponse = {
   accessToken: string;
   refreshToken: string;
+  expiredAt: string;
 };


### PR DESCRIPTION
- accesstoken 재발급 로직 구현 (expiredat 속성값통함)
- queryKeyFactory progress task 통합

<!--제목 템플릿-->
<!--[#1] 프로젝트 세팅 v1.0.0-->

# 📝작업 내용

## 1.  queryKeyFactory progress task 통합

## 2. TTokenResponse type 수정 

```ts
expiredAt: string;
```
속성 추가

## 3.  axios response interceptor 제거 -> authoption 에서 token 로직 관련 구현
```ts
if (
        token.expiredAt &&
        dayjs(token.expiredAt as string).isAfter(dayjs())
      ) {
        return token;
      }

      const response = await postRefreshToken({
        refreshToken: token.refreshToken as string,
      });

      if (response.success && response.result) {
        return {
          ...token,
          accessToken: response.result.accessToken,
          refreshToken: response.result.refreshToken,
          expiredAt: response.result.expiredAt,
        };
      } else {
        return {
          id: token.id,
          email: token.email,
          name: token.name,
          accessToken: undefined,
          refreshToken: undefined,
          expiredAt: undefined,
        };
      }
```
백엔드 분들에게 새로 내려받는 expiredAt 속성으로 시간 비교후에 refreshtoken 으로 accesstoken 발급받는 api 호출하는 방식입니다.



# 📷스크린샷(필요 시)

# 사용 방법

dayjs 라이브러리 새로 추가되었습니다.

# ✨PR Point

> refresh token 유효하지 않을시에 세션에 undefined 값을 내려주는 로직통해서 middleware.ts 파일에서 로그인 페이지로 redirect 해주는 로직 추가 구현 필요합니다.

> `export type TPostRefreshTokenRequest = { refreshToken: string };` request 타입 변경되었습니다.
