### PR TITLE
[#114] 여행 상세 할 일 API 연동

### DIFF
--- a/src/app/(authorized)/(trip)/trip/[id]/layout.tsx
+++ b/src/app/(authorized)/(trip)/trip/[id]/layout.tsx
@@ -1,0 +1,14 @@
+import NavTitle from '@ui/common/NavTitle';
+
+interface ITripLayoutProps {
+  children: React.ReactNode;
+}
+
+export default async function TripLayout({ children }: ITripLayoutProps) {
+  return (
+    <div className="flex min-h-full flex-1 flex-col gap-6">
+      <NavTitle />
+      {children}
+    </div>
+  );
+}

--- a/src/app/(authorized)/(trip)/trip/[id]/page.tsx
+++ b/src/app/(authorized)/(trip)/trip/[id]/page.tsx
@@ -1,4 +1,3 @@
-import NavTitle from '@ui/common/NavTitle';
 import TripNotesButton from '@ui/trip/TripNotesButton';
 import TripInfo from '@ui/trip/TripInfo';
 import TripTask from '@ui/trip/TripTask';
@@ -23,17 +22,17 @@ const tripInfo = {
   updatedAt: '2024-12-16T07:45:43.447Z',
 };
 
-export default function Trip() {
+export default function Trip({ params }: { params: { id: string } }) {
+  const { id } = params;
+
   return (
-    <div className="flex min-h-full flex-1 flex-col gap-[1.625rem]">
-      <NavTitle />
+    <>
       {/* 여행 상세 정보 */}
       <TripInfo tripInfo={tripInfo} />
       {/* 노트 모아보기 */}
       <TripNotesButton />
-      <div className="1000px"></div>
       {/* 여행 할 일 */}
-      <TripTask />
-    </div>
+      <TripTask id={Number(id)} />
+    </>
   );
 }

--- a/src/constant/Task.ts
+++ b/src/constant/Task.ts
@@ -1,8 +1,17 @@
+import { TTaskScope } from '@model/task.model';
+
 // 할 일 여행 상태
 export const TRIP_STATUS = {
   ready: '여행 준비',
   ongoing: '여행 중',
   done: '여행 완료',
+};
+
+// 할 일 공유 범위
+export const FILTER_MAPPING: Record<string, TTaskScope | null> = {
+  All: null,
+  공통: 'PUBLIC',
+  개인: 'PRIVATE',
 };
 
 // 데이터가 없을 경우 표시하는 메시지

--- a/src/constant/Task.ts
+++ b/src/constant/Task.ts
@@ -16,3 +16,8 @@ export const FILTER_MAPPING: Record<string, TTaskScope | null> = {
 
 // 데이터가 없을 경우 표시하는 메시지
 export const EMPTY_TASK_MESSAGE = '아직 할 일이 없어요.';
+
+// 할 일 popup 메세지
+export const TASK_POPUP_MESSAGE = {
+  deleteTask: '할 일을 삭제하시겠어요? \n 삭제된 할 일은 복구할 수 없습니다.',
+};

--- a/src/constant/queryKeyFactory.ts
+++ b/src/constant/queryKeyFactory.ts
@@ -7,7 +7,12 @@ import { TGetTripListProps } from '@model/trip.model';
 export const tasksQueryKeys = createQueryKeys('tasks', {
   list: (props: TGetTaskRequest) => ({
     // 동적 props 추가 필요
-    queryKey: ['tasksList'],
+    queryKey: [
+      'tasksList',
+      props.tripId,
+      props.taskScope && props.taskScope,
+      props.taskStatus && props.taskStatus,
+    ],
     queryFn: () => getTask(props),
   }),
 });

--- a/src/hooks/task/useDeleteTask.ts
+++ b/src/hooks/task/useDeleteTask.ts
@@ -1,0 +1,27 @@
+import { deleteTask } from '@lib/api/service/task.api';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+export const useDeleteTask = () => {
+  const queryClient = useQueryClient();
+  const mutation = useMutation({
+    mutationFn: async (taskId: number) => {
+      await deleteTask(taskId);
+      return taskId;
+    },
+    onSuccess: (taskId: number) => {
+      // TODO: 삭제 후 데이터 리프레쉬
+      queryClient.invalidateQueries({
+        queryKey: ['tasksList', taskId],
+      });
+      // queryClient.refetchQueries({
+      //   queryKey: ['tasksList', taskId],
+      // });
+    },
+    onError: (error) => {
+      // eslint-disable-next-line no-console
+      console.error('할일 삭제 중 오류 발생:', error);
+    },
+  });
+
+  return mutation;
+};

--- a/src/lib/api/service/task.api.ts
+++ b/src/lib/api/service/task.api.ts
@@ -53,9 +53,9 @@ export const getTaskDetail = async (data: TGetTaskDetailRequest) => {
   return response.data;
 };
 
-export const deleteTask = async (data: TDeleteTaskRequest) => {
+export const deleteTask = async (taskId: TDeleteTaskRequest) => {
   const response = await del<TResponse<TDeleteTaskResponse>>(
-    `/api/v1/torip/task?taskId=${data.taskId}`,
+    `/api/v1/torip/task/${taskId}`,
   );
   return response.data;
 };

--- a/src/lib/api/service/task.api.ts
+++ b/src/lib/api/service/task.api.ts
@@ -24,7 +24,7 @@ export const getTask = async (data: TGetTaskRequest) => {
     all: all.toString(),
   }).toString();
 
-  const response = await get<TResponse<TGetTaskResponse>>(
+  const response = await get<TResponse<TGetTaskResponse[]>>(
     `/api/v1/torip/task?${queryString}`,
   );
   return response.data;

--- a/src/model/task.model.ts
+++ b/src/model/task.model.ts
@@ -1,33 +1,43 @@
+export type TTaskStatus = 'BEFORE_TRIP' | 'DURING_TRIP' | 'AFTER_TRIP';
+export type TTaskScope = 'PUBLIC' | 'PRIVATE';
+
 export type TGetTaskRequest = {
   tripId: number;
   taskSeq: number;
-  taskStatus?: 'BEFORE_TRAVEL' | 'DURING_TRAVEL' | 'AFTER_TRAVEL';
-  taskScope?: 'PUBLIC' | 'PRIVATE';
+  taskStatus?: TTaskStatus;
+  taskScope?: TTaskScope;
   all: boolean;
+};
+
+export type TTaskAssignee = {
+  taskId: number;
+  userId: number;
+  username: string;
+  email: string;
 };
 
 export type TGetTaskResponse = {
   taskId: number;
-  travelName: string;
+  tripName: string;
   taskTitle: string;
-  taskFilePath: string;
-  taskStatus: 'BEFORE_TRAVEL' | 'DURING_TRAVEL' | 'AFTER_TRAVEL';
+  taskFilePath?: string;
+  taskStatus: TTaskStatus;
   taskDDay: string;
-  taskScope: 'PUBLIC' | 'PRIVATE';
-  taskCompletionDate: string;
-  taskCreatedBy: string;
-  taskCreatedAt: string;
-  taskModifiedBy: string;
-  taskUpdatedAt: string;
-  assignees: string[];
+  taskScope: TTaskScope;
+  taskCompletionDate?: string;
+  createdBy: string;
+  createdAt: string;
+  modifiedBy: string;
+  modifiedAt: string;
+  taskAssignees: TTaskAssignee[];
 };
 
 export type TTask = {
   travelId: number;
   taskId: number;
   taskTitle: string;
-  travelStatus: 'BEFORE_TRAVEL' | 'DURING_TRAVEL' | 'AFTER_TRAVEL';
-  scope: 'PUBLIC' | 'PRIVATE';
+  taskStatus: TTaskStatus;
+  taskScope: TTaskScope;
   completionDate: string;
   taskDDay?: string;
   filePath?: string;
@@ -39,8 +49,8 @@ export type TGetTaskDetailRequest = Pick<TTask, 'taskId'>;
 export type TGetTaskDetailResponse = {
   travelName: string;
   taskFilePath: string;
-  taskStatus: 'BEFORE_TRAVEL / DURING_TRAVEL / AFTER_TRAVEL';
-  taskScope: 'PUBLIC' | 'PRIVATE';
+  taskStatus: TTaskStatus;
+  taskScope: TTaskScope;
   taskCompletionDate: string;
   taskCreatedBy: string;
   taskCreatedAt: string;
@@ -56,7 +66,7 @@ export type TPutEditTaskResponse = number;
 
 export type TPostAddTaskResponse = number;
 
-export type TDeleteTaskRequest = Pick<TTask, 'taskId'>;
+export type TDeleteTaskRequest = number;
 
 export type TDeleteTaskResponse = number;
 

--- a/src/provider/QueryProvider.tsx
+++ b/src/provider/QueryProvider.tsx
@@ -1,13 +1,23 @@
 'use client';
 
-import { queryClient } from '@lib/api/queryClient';
-import { QueryClientProvider } from '@tanstack/react-query';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { useState } from 'react';
 
 export default function QueryProvider({
   children,
 }: {
   children: React.ReactNode;
 }) {
+  const [queryClient] = useState(
+    new QueryClient({
+      defaultOptions: {
+        queries: {
+          staleTime: 60 * 1000,
+        },
+      },
+    }),
+  );
+
   return (
     <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
   );

--- a/src/ui/card/taskCard/TaskCard.tsx
+++ b/src/ui/card/taskCard/TaskCard.tsx
@@ -1,6 +1,6 @@
 import { twMerge } from 'tailwind-merge';
 import { EMPTY_TASK_MESSAGE, TRIP_STATUS } from '@constant/task';
-import TodoProgressBar from './TaskProgressBar';
+import TaskProgressBar from './TaskProgressBar';
 import { TGetTaskResponse } from '@model/task.model';
 import TaskList from './TaskList';
 import EmptyMessage from '@ui/common/EmptyMessage';
@@ -16,9 +16,15 @@ interface ITaskCardProps {
 
 export default function TaskCard({
   status,
+  tripId,
   tasks,
   classNames,
 }: ITaskCardProps) {
+  const totalTasks = tasks?.length || 0;
+  const completedTasks =
+    tasks?.filter((task) => task.taskCompletionDate)?.length || 0;
+  const progress = totalTasks > 0 ? (completedTasks / totalTasks) * 100 : 0;
+
   return (
     <div
       className={twMerge(
@@ -32,8 +38,7 @@ export default function TaskCard({
       <div className="flex flex-col gap-2.5">
         {/* 여행 상태 */}
         <div className="text-lg font-bold leading-7">{TRIP_STATUS[status]}</div>
-        {/* todo 프로그래스 바 */}
-        <TodoProgressBar progress={80} />
+        <TaskProgressBar progress={progress} />
       </div>
       {/* todo list */}
       {tasks ? (

--- a/src/ui/card/taskCard/TaskCard.tsx
+++ b/src/ui/card/taskCard/TaskCard.tsx
@@ -1,7 +1,7 @@
 import { twMerge } from 'tailwind-merge';
+import { EMPTY_TASK_MESSAGE, TRIP_STATUS } from '@constant/task';
 import TodoProgressBar from './TaskProgressBar';
-import { TTask } from '@model/task.model';
-import { EMPTY_TASK_MESSAGE, TRIP_STATUS } from '@constant/Task';
+import { TGetTaskResponse } from '@model/task.model';
 import TaskList from './TaskList';
 import EmptyMessage from '@ui/common/EmptyMessage';
 
@@ -9,7 +9,8 @@ type TTripStatusKey = keyof typeof TRIP_STATUS;
 
 interface ITaskCardProps {
   status: TTripStatusKey;
-  tasks: TTask[] | null;
+  tripId: number;
+  tasks: TGetTaskResponse[] | null;
   classNames?: string;
 }
 
@@ -36,7 +37,7 @@ export default function TaskCard({
       </div>
       {/* todo list */}
       {tasks ? (
-        <TaskList tasks={tasks} />
+        <TaskList tripId={tripId} tasks={tasks} />
       ) : (
         <EmptyMessage message={EMPTY_TASK_MESSAGE} />
       )}

--- a/src/ui/card/taskCard/TaskItem.tsx
+++ b/src/ui/card/taskCard/TaskItem.tsx
@@ -3,23 +3,29 @@
 'use client';
 
 import { memo } from 'react';
-import { TTask } from '@model/task.model';
+import { TGetTaskResponse } from '@model/task.model';
 import CheckBox from '@ui/common/CheckBox';
 import ButtonIconGroup from '@ui/common/ButtonIconGroup';
 
-type TTaskItemProps = Omit<TTask, 'travelId'>;
+interface ITaskItemProps
+  extends Omit<
+    TGetTaskResponse,
+    'tripName' | 'createdBy' | 'createdAt' | 'modifiedBy' | 'modifiedAt'
+  > {
+  tripId: number;
+}
 
-// TODO: 디자인 시안에 맞춰 props 데이터 수정 필요
 function TaskItem({
+  tripId,
   taskId,
   taskTitle,
-  travelStatus,
-  scope,
-  completionDate,
+  taskStatus,
+  taskScope,
+  taskCompletionDate,
   taskDDay,
-  filePath,
-  assignees,
-}: TTaskItemProps) {
+  taskFilePath,
+  taskAssignees,
+}: ITaskItemProps) {
   const handleFileClick = () => {
     // TODO: 파일 다운로드 모달
   };

--- a/src/ui/card/taskCard/TaskItem.tsx
+++ b/src/ui/card/taskCard/TaskItem.tsx
@@ -6,6 +6,9 @@ import { memo } from 'react';
 import { TGetTaskResponse } from '@model/task.model';
 import CheckBox from '@ui/common/CheckBox';
 import ButtonIconGroup from '@ui/common/ButtonIconGroup';
+import { useDeleteTask } from '@hooks/task/useDeleteTask';
+import { usePopupStore } from '@store/popup.store';
+import { TASK_POPUP_MESSAGE } from '@constant/task';
 
 interface ITaskItemProps
   extends Omit<
@@ -26,11 +29,25 @@ function TaskItem({
   taskFilePath,
   taskAssignees,
 }: ITaskItemProps) {
+  const deleteTask = useDeleteTask();
+
+  const { showPopup } = usePopupStore();
+
   const handleFileClick = () => {
     // TODO: 파일 다운로드 모달
   };
-  const handleDocClick = () => {
-    // TODO: 노트 모아보기로 이동
+  const handleEditTaskClick = () => {
+    // TODO: 할 일 수정하기
+  };
+  const handleDeleteTaskClick = () => {
+    showPopup({
+      popupText: TASK_POPUP_MESSAGE.deleteTask,
+      showCancelButton: true,
+      confirmButtonText: '확인',
+      onConfirm: () => {
+        deleteTask.mutate(taskId);
+      },
+    });
   };
 
   return (
@@ -38,8 +55,11 @@ function TaskItem({
       {/* TODO: 할 일 체크 */}
       <CheckBox>{taskTitle}</CheckBox>
       <ButtonIconGroup
+        taskId={taskId}
+        hasFilePath={!taskFilePath ? false : true}
         onFileClick={handleFileClick}
-        onDocClick={handleDocClick}
+        onEditTaskClick={handleEditTaskClick}
+        onDeleteTaskClick={handleDeleteTaskClick}
       />
     </li>
   );

--- a/src/ui/card/taskCard/TaskList.tsx
+++ b/src/ui/card/taskCard/TaskList.tsx
@@ -1,24 +1,26 @@
-import { TTask } from '@model/task.model';
+import { TGetTaskResponse } from '@model/task.model';
 import TaskItem from './TaskItem';
 
 interface ITaskListProps {
-  tasks: TTask[];
+  tripId: number;
+  tasks: TGetTaskResponse[];
 }
 
-export default function TaskList({ tasks }: ITaskListProps) {
+export default function TaskList({ tripId, tasks }: ITaskListProps) {
   return (
     <ul className="scroll flex flex-1 flex-col gap-2 overflow-y-auto">
       {tasks.map((task) => (
         <TaskItem
           key={task.taskId}
+          tripId={tripId}
           taskId={task.taskId}
           taskTitle={task.taskTitle}
-          travelStatus={task.travelStatus}
-          scope={task.scope}
-          completionDate={task.completionDate}
+          taskStatus={task.taskStatus}
+          taskScope={task.taskScope}
+          taskCompletionDate={task.taskCompletionDate}
           taskDDay={task.taskDDay}
-          filePath={task.filePath}
-          assignees={task.assignees}
+          taskFilePath={task.taskFilePath}
+          taskAssignees={task.taskAssignees}
         />
       ))}
     </ul>

--- a/src/ui/card/taskCard/TaskProgressBar.tsx
+++ b/src/ui/card/taskCard/TaskProgressBar.tsx
@@ -4,7 +4,7 @@ interface ITaskProgressBar {
   progress: number; // 할 일 완료도
 }
 
-export default function TodoProgressBar({ progress }: ITaskProgressBar) {
+export default function TaskProgressBar({ progress }: ITaskProgressBar) {
   return (
     <div className="item-center gap-2 rounded-full border border-slate-100 bg-white px-2 py-[.125rem]">
       <Progress

--- a/src/ui/carousel/TaskCarousel.tsx
+++ b/src/ui/carousel/TaskCarousel.tsx
@@ -1,4 +1,4 @@
-import { TTask } from '@model/task.model';
+import { TGetTaskResponse, TTaskStatus } from '@model/task.model';
 import TaskCard from '@ui/card/taskCard/TaskCard';
 import { Swiper, SwiperSlide } from 'swiper/react';
 import SwiperCore from 'swiper';
@@ -9,12 +9,14 @@ import 'swiper/css/navigation';
 import { twMerge } from 'tailwind-merge';
 
 interface ITaskCarouselProps {
-  tasks: TTask[]; // 할 일 데이터
+  tripId: number; // 여행 ID
+  tasks: TGetTaskResponse[]; // 할 일 데이터
   height?: string; // 캐러셀 height 값 지정
   className?: string; // 캐러셀 스타일 지정
 }
 
 export default function TaskCarousel({
+  tripId,
   tasks,
   height,
   className,
@@ -23,10 +25,10 @@ export default function TaskCarousel({
 
   const groupedTasks = tasks.reduce(
     (acc, task) => {
-      acc[task.travelStatus] = [...(acc[task.travelStatus] || []), task];
+      acc[task.taskStatus] = [...(acc[task.taskStatus] || []), task];
       return acc;
     },
-    {} as Record<TTask['travelStatus'], TTask[]>,
+    {} as Record<TTaskStatus, TGetTaskResponse[]>,
   );
 
   return (
@@ -60,13 +62,25 @@ export default function TaskCarousel({
         style={{ height: height ? `${height}` : 'auto' }}
       >
         <SwiperSlide className="h-full">
-          <TaskCard status="ready" tasks={groupedTasks['BEFORE_TRAVEL']} />
+          <TaskCard
+            status="ready"
+            tripId={tripId}
+            tasks={groupedTasks['BEFORE_TRIP']}
+          />
         </SwiperSlide>
         <SwiperSlide>
-          <TaskCard status="ongoing" tasks={groupedTasks['DURING_TRAVEL']} />
+          <TaskCard
+            status="ongoing"
+            tripId={tripId}
+            tasks={groupedTasks['DURING_TRIP']}
+          />
         </SwiperSlide>
         <SwiperSlide>
-          <TaskCard status="done" tasks={groupedTasks['AFTER_TRAVEL']} />
+          <TaskCard
+            status="done"
+            tripId={tripId}
+            tasks={groupedTasks['AFTER_TRIP']}
+          />
         </SwiperSlide>
       </Swiper>
     </div>

--- a/src/ui/common/ButtonIconGroup.tsx
+++ b/src/ui/common/ButtonIconGroup.tsx
@@ -1,5 +1,6 @@
 import { twMerge } from 'tailwind-merge';
 import DropdownMenu from './DropdownMenu';
+import Link from 'next/link';
 
 /**
  * 할일 옆에 나오는 아이콘 그룹 컴포넌트입니다.
@@ -9,21 +10,28 @@ import DropdownMenu from './DropdownMenu';
  * - 문서 버튼: 문서 관련 작업을 수행합니다.
  * - 케밥 버튼: 추가 옵션을 표시합니다.
  *
- * @component
- *
- * @param {function} onFileClick - 파일 버튼 클릭 시 호출되는 핸들러
- * @param {function} onDocClick - 문서 버튼 클릭 시 호출되는 핸들러
- *
+ * taskId - 할일 id
+ * hasFilePath - 파일 존재 여부
+ * onFileClick - 파일 버튼 클릭 시 호출되는 핸들러
+ * onEditTaskClick - 할일 수정 이벤트 핸들러
+ * onDeleteTaskClick - 할일 삭제 이벤트 핸들러
+ * className - 사용자 정의 스타일링
  */
 interface IButtonIconGroupProps {
+  taskId: number;
+  hasFilePath: boolean;
   onFileClick: () => void;
-  onDocClick: () => void;
+  onEditTaskClick: () => void;
+  onDeleteTaskClick: () => void;
   className?: string;
 }
 
 export default function ButtonIconGroup({
+  taskId,
+  hasFilePath,
   onFileClick,
-  onDocClick,
+  onEditTaskClick,
+  onDeleteTaskClick,
   className,
 }: IButtonIconGroupProps) {
   const buttonStyle =
@@ -31,26 +39,25 @@ export default function ButtonIconGroup({
 
   return (
     <div className={twMerge('flex gap-2', className)}>
-      <button
-        className={twMerge(buttonStyle, 'text-slate-500')}
-        onClick={onFileClick}
-      >
-        {/* 파일 아이콘 부분 */}
-      </button>
-      <button
-        className={twMerge(buttonStyle, 'text-primary')}
-        onClick={onDocClick}
-      >
-        {/* 문서 아이콘 부분 */}
-      </button>
+      {hasFilePath && (
+        <button
+          className={twMerge(buttonStyle, 'text-slate-500')}
+          onClick={onFileClick}
+        >
+          {/* 파일 아이콘 부분 */}
+        </button>
+      )}
+      <Link href={`/note-all-task/${taskId}`}>
+        <button className={twMerge(buttonStyle, 'text-primary')}>
+          {/* 문서 아이콘 부분 */}
+        </button>
+      </Link>
       {/* 케밥 메뉴 */}
       <DropdownMenu
         items={[
           // TODO: 기능 추가 필요
-          /* eslint-disable no-console */
-          { label: '수정하기', onClick: () => console.log('Edit clicked') },
-          { label: '삭제하기', onClick: () => console.log('Delete clicked') },
-          /* eslint-disable no-console */
+          { label: '수정하기', onClick: onEditTaskClick },
+          { label: '삭제하기', onClick: onDeleteTaskClick },
         ]}
       >
         {/* 케밥 아이콘 부분 */} :

--- a/src/ui/common/FilterButton.tsx
+++ b/src/ui/common/FilterButton.tsx
@@ -5,15 +5,24 @@ import { twMerge } from 'tailwind-merge';
 
 const FILTERS = ['All', '공통', '개인'];
 
-export default function FilterButton() {
+interface IFilterButtonProps {
+  onClick: (filter: string) => void; // 클릭 이벤트 핸들러
+}
+
+export default function FilterButton({ onClick }: IFilterButtonProps) {
   const [activeFilter, setActiveFilter] = useState<string>('All');
+
+  const handleFilterClick = (filter: string) => {
+    setActiveFilter(filter);
+    onClick(filter);
+  };
 
   return (
     <div className="inline-flex gap-2.5">
       {FILTERS.map((filter) => (
         <button
           key={filter}
-          onClick={() => setActiveFilter(filter)}
+          onClick={() => handleFilterClick(filter)}
           className={twMerge(
             'rounded-[17px] border px-3 py-1 text-sm font-medium leading-tight',
             filter === activeFilter

--- a/src/ui/trip/TripTask.tsx
+++ b/src/ui/trip/TripTask.tsx
@@ -1,64 +1,46 @@
 'use client';
 
-import { TTask } from '@model/task.model';
 import TaskCarousel from '@ui/carousel/TaskCarousel';
 import FilterButton from '@ui/common/FilterButton';
-import ShowAllTasksButton from './tripTask/ShowAllTasksButton';
 import AddTaskButton from './tripTask/AddTaskButton';
+import { useGetTasks } from '@hooks/task/useGetTasks';
+import { TTrip } from '@model/trip.model';
+import { useState } from 'react';
+import { TTaskScope } from '@model/task.model';
+import { FILTER_MAPPING } from '@constant/task';
 
-// TODO: API 연동 후 제거 예정
-const tasks: TTask[] = [
-  {
-    travelId: 1,
-    taskId: 101,
-    taskTitle: '비행기 티켓 예약하기',
-    travelStatus: 'BEFORE_TRAVEL',
-    scope: 'PRIVATE',
-    completionDate: '2024-12-15',
-    taskDDay: 'D-3',
-    filePath: '/files/ticket.pdf',
-    assignees: ['Alice', 'Bob'],
-  },
-  {
-    travelId: 1,
-    taskId: 102,
-    taskTitle: '호텔 예약 완료하기',
-    travelStatus: 'BEFORE_TRAVEL',
-    scope: 'PUBLIC',
-    completionDate: '2024-12-18',
-    assignees: ['Charlie'],
-  },
-  {
-    travelId: 1,
-    taskId: 103,
-    taskTitle: '관광 일정 짜기',
-    travelStatus: 'BEFORE_TRAVEL',
-    scope: 'PRIVATE',
-    completionDate: '2024-12-20',
-  },
-  {
-    travelId: 1,
-    taskId: 104,
-    taskTitle: '여행지 사진 정리',
-    travelStatus: 'AFTER_TRAVEL',
-    scope: 'PUBLIC',
-    completionDate: '2024-12-25',
-    filePath: '/files/photos.zip',
-  },
-];
+type TTripTaskProps = Pick<TTrip, 'id'>;
 
-export default function TripTask() {
+export default function TripTask({ id }: TTripTaskProps) {
+  const [taskScope, setTaskScope] = useState<TTaskScope | null>(null);
+
+  const params = {
+    tripId: id,
+    taskSeq: 0,
+    all: true,
+    ...(taskScope ? { taskScope } : {}),
+  };
+  const { data } = useGetTasks(params);
+
+  const handleTaskFilterClick = (filter: string) => {
+    const scope = FILTER_MAPPING[filter];
+    setTaskScope(scope);
+  };
+
   return (
-    <div className="section-box flex flex-col gap-5">
+    <div className="section-box flex flex-1 flex-col gap-5">
       <div className="flex items-center justify-between">
         <h4 className="text-lg font-semibold leading-7 text-slate-800">Todo</h4>
-        <ShowAllTasksButton />
       </div>
       <div className="flex items-center justify-between">
-        <FilterButton />
+        <FilterButton onClick={handleTaskFilterClick} />
         <AddTaskButton />
       </div>
-      <TaskCarousel tasks={tasks} height="500px" />
+      <TaskCarousel
+        tripId={id}
+        tasks={data?.result ? data?.result : []}
+        height="500px"
+      />
     </div>
   );
 }

--- a/src/ui/trip/TripTask.tsx
+++ b/src/ui/trip/TripTask.tsx
@@ -8,6 +8,8 @@ import { TTrip } from '@model/trip.model';
 import { useState } from 'react';
 import { TTaskScope } from '@model/task.model';
 import { FILTER_MAPPING } from '@constant/task';
+import { useModalStore } from '@store/modal.store';
+import TodoModal from '@ui/common/TodoModal';
 
 type TTripTaskProps = Pick<TTrip, 'id'>;
 
@@ -22,6 +24,15 @@ export default function TripTask({ id }: TTripTaskProps) {
   };
   const { data } = useGetTasks(params);
 
+  const { showModal } = useModalStore();
+
+  const handleAddTaskClick = () => {
+    showModal({
+      title: '할 일 생성',
+      content: <TodoModal />,
+    });
+  };
+
   const handleTaskFilterClick = (filter: string) => {
     const scope = FILTER_MAPPING[filter];
     setTaskScope(scope);
@@ -34,7 +45,7 @@ export default function TripTask({ id }: TTripTaskProps) {
       </div>
       <div className="flex items-center justify-between">
         <FilterButton onClick={handleTaskFilterClick} />
-        <AddTaskButton />
+        <AddTaskButton onClick={handleAddTaskClick} />
       </div>
       <TaskCarousel
         tripId={id}


### PR DESCRIPTION
<!--제목 템플릿-->
<!--[#1] 프로젝트 세팅 v1.0.0-->

# 📝작업 내용
- [x] 여행 상세 navTitle layout.tsx으로 분리
- [x] QueryClient defaultOptions에 (클라이언트에서 바로 api 호출하지 않도록) staleTime 설정 
- 할 일 목록 
  - [x] 공유 범위에 따라 API 호출 (할일 목록 쿼리키 id, 공유 범위, 여행 상태에 따라 받도록 추가)
  - [x] 할 일 공유 범위 api와 매칭 상수화 
  - [x] api 수정 사항 반영 및 type 수정 (travel -> trip)
  - [x] 전체 보기 버튼 제거
  - [x] 파일 아이콘 파일 저장 여부에 따라 보이도록 처리
  - [x] 할 일 노트 아이콘 클릭 시 노트 모아보기로 이동
- 할 일 추가 
  - [x] 할 일 추가 버튼 클릭 시 할 일 생성 모달 열기
- 프로그래스 바 
  - [x] `taskCompletionDate` 따라 여행 상태별 할 일 퍼센트 계산 후 프로그래스 바 반영
  - [x] TaskProgressBar로 컴포넌트명 통일
- 할 일 삭제 하기
  - [x] 할 일 삭제 API 쿼리 키 및 `useDeleteTask`훅 추가
  - [x] 할 일 삭제 메세지 상수화
  - [x] 할 일 삭제 시 팝업창 열기 
  - [x] 확인 버튼 클릭 시 할 일 삭제
  - [ ] 삭제 후 API 리프레쉬
- 할 일 수정 
  - [x] 할 일 수정 모달에 `tripId` 넘겨주기 위해 props 추가
  - [ ] 할 일 수정 모달 연결
# ✨PR Point
> 작업이 다 연결되어 있다보니 양이 많은 것 같습니다 ㅠㅠ 양해부탁드려욥 ㅠㅠ

> tanstack query 에서 prefetch 설정하기 위해 defaultOptions을 설정했습니다. SSR에서는 클라이언트에서 즉시 refetch하는 것을 피하기 위해 staleTime을 0보다 크게 설정하는 것이 좋다고하여 설정하였습니다. 공식 문서 참고 바랍니다. 그리고 적용하려다 어려움이 있어 추후 적용하려 합니다. ㅠㅠ
```
const [queryClient] = useState(
    new QueryClient({
      defaultOptions: {
        queries: {
          staleTime: 60 * 1000,
        },
      },
    }),
  );
```

> 할 일 수정하기는 추가적으로 구현이 필요합니다. 할 일 삭제 시 쿼리키 초기화를 시켜 api를 재호출하도록 했는데.. 제대로 적용이 되지 않아 수정 중입니다ㅠㅠ

> 할일 목록 쿼리키 id, 공유 범위, 여행 상태에 따라 받도록 추가해 뒀고 훅 작성해뒀는데 개성 사항이 있다면 편하게 말씀해주세요!

> @kwonsuhyuk 파일 다운로드 popup 부탁드립니다!!