### PR TITLE
[#97] 여행 정보 API 연동

### DIFF
--- a/src/app/(authorized)/(trip)/trip/[id]/page.tsx
+++ b/src/app/(authorized)/(trip)/trip/[id]/page.tsx
@@ -2,33 +2,13 @@ import TripNotesButton from '@ui/trip/TripNotesButton';
 import TripInfo from '@ui/trip/TripInfo';
 import TripTask from '@ui/trip/TripTask';
 
-// TODO: API 연동시 제거 예정
-const tripInfo = {
-  id: 1,
-  name: '제주도 여행',
-  startDate: '2021-10-01',
-  endDate: '2021-10-05',
-  owner: {
-    id: 1,
-    username: 'test',
-    email: 'test@test.com',
-  },
-  createdAt: '2024-12-16T07:45:43.447Z',
-  lastUpdatedUser: {
-    id: 1,
-    username: 'test',
-    email: 'test@test.com',
-  },
-  updatedAt: '2024-12-16T07:45:43.447Z',
-};
-
 export default function Trip({ params }: { params: { id: string } }) {
   const { id } = params;
 
   return (
     <>
       {/* 여행 상세 정보 */}
-      <TripInfo tripInfo={tripInfo} />
+      <TripInfo id={Number(id)} />
       {/* 노트 모아보기 */}
       <TripNotesButton id={Number(id)} />
       {/* 여행 할 일 */}

--- a/src/app/(authorized)/(trip)/trip/[id]/page.tsx
+++ b/src/app/(authorized)/(trip)/trip/[id]/page.tsx
@@ -30,7 +30,7 @@ export default function Trip({ params }: { params: { id: string } }) {
       {/* 여행 상세 정보 */}
       <TripInfo tripInfo={tripInfo} />
       {/* 노트 모아보기 */}
-      <TripNotesButton />
+      <TripNotesButton id={Number(id)} />
       {/* 여행 할 일 */}
       <TripTask id={Number(id)} />
     </>

--- a/src/constant/queryKeyFactory.ts
+++ b/src/constant/queryKeyFactory.ts
@@ -1,4 +1,5 @@
 import { getTask, getTaskProgress } from '@lib/api/service/task.api';
+import { getTrip } from '@lib/api/service/trip.api';
 import { getTripList } from '@lib/api/service/trip.api';
 import { createQueryKeys } from '@lukemorales/query-key-factory';
 import { TGetTaskRequest } from '@model/task.model';
@@ -25,5 +26,9 @@ export const tripQueryKeys = createQueryKeys('trip', {
   list: (query: TGetTripListProps) => ({
     queryKey: ['tripList'],
     queryFn: () => getTripList(query),
+  }),
+  detail: (id: number) => ({
+    queryKey: [id],
+    queryFn: () => getTrip(id),
   }),
 });

--- a/src/constant/trip.ts
+++ b/src/constant/trip.ts
@@ -1,0 +1,3 @@
+export const TRIP_POPUP_MESSAGE = {
+  deleteTrip: '여행을 삭제하시겠어요? \n 삭제된 여행은 복구할 수 없습니다.',
+};

--- a/src/hooks/trip/useDeleteTrip.ts
+++ b/src/hooks/trip/useDeleteTrip.ts
@@ -1,0 +1,24 @@
+import { tripQueryKeys } from '@constant/queryKeyFactory';
+import { deleteTrip } from '@lib/api/service/trip.api';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+export const useDeleteTrip = () => {
+  const queryClient = useQueryClient();
+  const mutation = useMutation({
+    mutationFn: async (id: number) => {
+      await deleteTrip(id);
+      return id;
+    },
+    onSuccess: (id: number) => {
+      queryClient.invalidateQueries({
+        queryKey: tripQueryKeys.detail(id).queryKey,
+      });
+    },
+    onError: (error) => {
+      // eslint-disable-next-line no-console
+      console.error('여행 삭제 중 오류 발생:', error);
+    },
+  });
+
+  return mutation;
+};

--- a/src/hooks/trip/useGetTrip.ts
+++ b/src/hooks/trip/useGetTrip.ts
@@ -1,0 +1,6 @@
+import { useQuery } from '@tanstack/react-query';
+import { tripQueryKeys } from '@constant/queryKeyFactory';
+
+export const useGetTrip = (id: number) => {
+  return useQuery(tripQueryKeys.detail(id));
+};

--- a/src/lib/api/service/trip.api.ts
+++ b/src/lib/api/service/trip.api.ts
@@ -14,14 +14,14 @@ import {
 import { del, get, patch, post } from '../axios';
 
 export const postTrip = async (data: TPostTripRequest) => {
-  const response = await post<TPostTripResponse>('/api/v1/torip/travel', data);
+  const response = await post<TPostTripResponse>('/api/v1/torip/trip', data);
 
   return response.data;
 };
 
 export const getJoinTripList = async (id: number) => {
   const response = await get<TJoinTripListResponse>(
-    `api/v1/torip/travel/${id}/request`,
+    `api/v1/torip/trip/${id}/request`,
   );
 
   return response.data;
@@ -29,7 +29,15 @@ export const getJoinTripList = async (id: number) => {
 
 export const postJoinTrip = async (id: number) => {
   const response = await post<TJoinTripResponse>(
-    `api/v1/torip/travel/${id}/request`,
+    `api/v1/torip/trip/${id}/request`,
+  );
+
+  return response.data;
+};
+
+export const postRejectTrip = async (id: number) => {
+  const response = await post<TAcceptTripResponse>(
+    `/api/1v/torip/trip/request/${id}/reject`,
   );
 
   return response.data;
@@ -37,27 +45,27 @@ export const postJoinTrip = async (id: number) => {
 
 export const postAcceptTrip = async (id: number) => {
   const response = await post<TAcceptTripResponse>(
-    `api/v1/torip/travel/request/${id}/accept`,
+    `api/v1/torip/trip/request/${id}/accept`,
   );
 
   return response.data;
 };
 
 export const getTrip = async (id: number) => {
-  const response = await get<TGetTripResponse>(`api/v1/torip/travel/${id}`);
+  const response = await get<TGetTripResponse>(`api/v1/torip/trip/${id}`);
 
   return response.data;
 };
 
 export const deleteTrip = async (id: number) => {
-  const response = await del<TDeleteTripResponse>(`api/v1/torip/travel/${id}`);
+  const response = await del<TDeleteTripResponse>(`api/v1/torip/trip/${id}`);
 
   return response.data;
 };
 
 export const patchTrip = async (id: number, data: TPatchTripRequest) => {
   const response = await patch<TGetTripResponse>(
-    `api/v1/torip/travel/${id}`,
+    `api/v1/torip/trip/${id}`,
     data,
   );
 
@@ -66,13 +74,13 @@ export const patchTrip = async (id: number, data: TPatchTripRequest) => {
 
 export const getTripMembers = async (id: number) => {
   const response = await get<TGetTripMembersResponse>(
-    `api/v1/torip/travel/${id}/members`,
+    `api/v1/torip/trip/${id}/members`,
   );
 
   return response.data;
 };
 
-// const response = await getTravelList({lastSeenId: 3});
+// const response = await gettripList({lastSeenId: 3});
 export const getTripList = async (query: TGetTripListProps) => {
   const response = await get<TGetTripListResponse>(`api/v1/torip/trip/list`, {
     params: query,

--- a/src/model/trip.model.ts
+++ b/src/model/trip.model.ts
@@ -1,6 +1,7 @@
 import { TResponse } from './model';
 
 type TUserResponse = {
+  id: number;
   username: string;
   email: string;
 };
@@ -17,14 +18,14 @@ export type TTrip = {
 };
 
 export type TJoinTrip = {
-  travelName: string;
+  tripName: string;
   invitee: TUserResponse;
   status: 'Accepted' | 'Pending' | 'Rejected';
   createdAt: string;
   updatedAt: string;
 };
 
-// post - /api/v1/torip/travel
+// post - /api/v1/torip/trip
 export type TPostTripRequest = {
   name: string;
   startDate: string;
@@ -40,16 +41,19 @@ export type TJoinTripListResponse = TResponse<TJoinTrip[]>;
 // post - /api/v1/torip/{id}/request
 export type TJoinTripResponse = TResponse<TJoinTrip>;
 
+// post - /api/v1/torip/request/{id}/reject
+export type TRejectTripResponse = TResponse<TJoinTrip>;
+
 // post - /api/v1/torip/request/{id}/accept
 export type TAcceptTripResponse = TResponse<TJoinTrip>;
 
-// get - /api/v1/torip/travel/{id}
+// get - /api/v1/torip/trip/{id}
 export type TGetTripResponse = TResponse<TTrip>;
 
-// delete - /api/v1/torip/travel/{id}
+// delete - /api/v1/torip/trip/{id}
 export type TDeleteTripResponse = TResponse<Record<string, never>>;
 
-// patch - /api/v1/torip/travel/{id}
+// patch - /api/v1/torip/trip/{id}
 export type TPatchTripRequest = {
   name: string;
   startDate: string;
@@ -58,10 +62,10 @@ export type TPatchTripRequest = {
 
 export type TPatchTripResponse = TResponse<TTrip>;
 
-// get - /api/v1/torip/travel/{id}/members
+// get - /api/v1/torip/trip/{id}/members
 export type TGetTripMembersResponse = TResponse<TUserResponse[]>;
 
-// get - /api/v1/torip/travel/list
+// get - /api/v1/torip/trip/list
 /**
  
 @property {number}

--- a/src/ui/common/Skeleton.tsx
+++ b/src/ui/common/Skeleton.tsx
@@ -1,0 +1,26 @@
+import { twMerge } from 'tailwind-merge';
+
+interface ISkeletonProps {
+  className?: string; // 스타일 사용자 정의
+  isSquare?: boolean; // 정사각 1:1 비율
+  isCircle?: boolean; // 원형
+}
+
+const Skeleton = ({
+  isSquare = false, // 정사각
+  isCircle = false, // 원
+  className,
+}: ISkeletonProps) => {
+  return (
+    <div
+      className={twMerge(
+        'h-5 w-full animate-pulse rounded-md bg-gray-200',
+        isCircle && 'rounded-full',
+        className,
+      )}
+      style={isSquare ? { aspectRatio: '1 / 1' } : undefined}
+    />
+  );
+};
+
+export default Skeleton;

--- a/src/ui/trip/TripInfo.tsx
+++ b/src/ui/trip/TripInfo.tsx
@@ -5,12 +5,13 @@ import DropdownMenu from '@ui/common/DropdownMenu';
 import TripMember from './tripMember/TripMemberModal';
 import { twMerge } from 'tailwind-merge';
 import { TTrip } from '@model/trip.model';
+import { useGetTrip } from '@hooks/trip/useGetTrip';
+import Skeleton from '@ui/common/Skeleton';
 
-interface ITripInfoProps {
-  tripInfo: TTrip;
-}
+type TTripInfoProps = Pick<TTrip, 'id'>;
 
-export default function TripInfo({ tripInfo }: ITripInfoProps) {
+export default function TripInfo({ id }: TTripInfoProps) {
+  const { data: tripInfo, isLoading } = useGetTrip(id);
   const { showModal } = useModalStore();
 
   const handleShowTripMember = () => {
@@ -19,6 +20,17 @@ export default function TripInfo({ tripInfo }: ITripInfoProps) {
       content: <TripMember />,
     });
   };
+
+  if (isLoading) {
+    return (
+      <section className="section-box min-h-[136px]">
+        <div className="flex flex-col gap-3 py-4">
+          <Skeleton className="h-7 w-52" />
+          <Skeleton className="h-8 w-32" />
+        </div>
+      </section>
+    );
+  }
 
   return (
     <section
@@ -29,15 +41,19 @@ export default function TripInfo({ tripInfo }: ITripInfoProps) {
         } as React.CSSProperties
       }
       className={twMerge(
-        'section-box relative overflow-hidden bg-cover bg-center bg-no-repeat',
-        'before:to--[#888888]/30 before:absolute before:inset-0 before:bg-gradient-to-r before:from-black before:opacity-50 before:content-[""]',
-        'bg-[image:var(--bg-img)]',
+        'section-box relative min-h-[136px] overflow-hidden bg-cover bg-center bg-no-repeat',
+        // 'before:to--[#888888]/30 before:absolute before:inset-0 before:bg-gradient-to-r before:from-black before:opacity-50 before:content-[""]',
+        // 'bg-[image:var(--bg-img)]',
         // backgroundImage && 'bg-[image:var(--bg-img)]',
       )}
     >
-      <div className="relative z-10 flex flex-col gap-3 py-4 text-white">
-        <h3 className="text-lg font-semibold leading-7">{tripInfo.name}</h3>
-        <div className="text-[2rem] font-black leading-none text-white">
+      <div className="relative z-10 flex flex-col gap-3 py-4">
+        <h3 className="text-lg font-semibold leading-7">
+          {tripInfo && tripInfo?.success
+            ? tripInfo?.result.name
+            : tripInfo?.message}
+        </h3>
+        <div className="text-[2rem] font-black leading-none">
           {/* TODO: D-Day */}
           D-14
         </div>
@@ -53,7 +69,7 @@ export default function TripInfo({ tripInfo }: ITripInfoProps) {
             { label: '삭제하기', onClick: () => console.log('Share clicked') },
             /* eslint-disable no-console */
           ]}
-          className="bg-transparent font-black text-white"
+          className="bg-transparent font-black"
         >
           {/* 케밥 아이콘 부분 */} :
         </DropdownMenu>

--- a/src/ui/trip/TripInfo.tsx
+++ b/src/ui/trip/TripInfo.tsx
@@ -6,6 +6,10 @@ import TripMember from './tripMember/TripMemberModal';
 import { twMerge } from 'tailwind-merge';
 import { TTrip } from '@model/trip.model';
 import { useGetTrip } from '@hooks/trip/useGetTrip';
+import { useDeleteTrip } from '@hooks/trip/useDeleteTrip';
+import { usePopupStore } from '@store/popup.store';
+import { useRouter } from 'next/navigation';
+import { TRIP_POPUP_MESSAGE } from '@constant/trip';
 import Skeleton from '@ui/common/Skeleton';
 import { calculateDDday } from '@util/\bcalculateDDay';
 
@@ -13,7 +17,12 @@ type TTripInfoProps = Pick<TTrip, 'id'>;
 
 export default function TripInfo({ id }: TTripInfoProps) {
   const { data: tripInfo, isLoading } = useGetTrip(id);
+  const deleteTrip = useDeleteTrip();
+
   const { showModal } = useModalStore();
+  const { showPopup } = usePopupStore();
+
+  const router = useRouter();
 
   const dDay =
     tripInfo && tripInfo?.success
@@ -24,6 +33,25 @@ export default function TripInfo({ id }: TTripInfoProps) {
     showModal({
       title: '멤버 관리',
       content: <TripMember />,
+    });
+  };
+
+  const handleEditTrip = () => {
+    // TODO: 여행 수정하기
+  };
+
+  const handleDeleteTrip = () => {
+    showPopup({
+      popupText: TRIP_POPUP_MESSAGE.deleteTrip,
+      showCancelButton: true,
+      confirmButtonText: '확인',
+      onConfirm: () => {
+        deleteTrip.mutate(id, {
+          onSuccess: () => {
+            router.push('/');
+          },
+        });
+      },
     });
   };
 
@@ -68,8 +96,8 @@ export default function TripInfo({ id }: TTripInfoProps) {
             /* eslint-disable no-console */
             { label: '공유하기', onClick: () => console.log('Edit clicked') },
             { label: '멤버관리', onClick: handleShowTripMember },
-            { label: '수정하기', onClick: () => console.log('Share clicked') },
-            { label: '삭제하기', onClick: () => console.log('Share clicked') },
+            { label: '수정하기', onClick: handleEditTrip },
+            { label: '삭제하기', onClick: handleDeleteTrip },
             /* eslint-disable no-console */
           ]}
           className="bg-transparent font-black"

--- a/src/ui/trip/TripInfo.tsx
+++ b/src/ui/trip/TripInfo.tsx
@@ -7,12 +7,18 @@ import { twMerge } from 'tailwind-merge';
 import { TTrip } from '@model/trip.model';
 import { useGetTrip } from '@hooks/trip/useGetTrip';
 import Skeleton from '@ui/common/Skeleton';
+import { calculateDDday } from '@util/\bcalculateDDay';
 
 type TTripInfoProps = Pick<TTrip, 'id'>;
 
 export default function TripInfo({ id }: TTripInfoProps) {
   const { data: tripInfo, isLoading } = useGetTrip(id);
   const { showModal } = useModalStore();
+
+  const dDay =
+    tripInfo && tripInfo?.success
+      ? calculateDDday(tripInfo.result.startDate)
+      : 'D-0';
 
   const handleShowTripMember = () => {
     showModal({
@@ -53,10 +59,7 @@ export default function TripInfo({ id }: TTripInfoProps) {
             ? tripInfo?.result.name
             : tripInfo?.message}
         </h3>
-        <div className="text-[2rem] font-black leading-none">
-          {/* TODO: D-Day */}
-          D-14
-        </div>
+        <div className="text-[2rem] font-black leading-none">{dDay}</div>
       </div>
       <div className="absolute right-4 top-4">
         <DropdownMenu

--- a/src/ui/trip/TripNotesButton.tsx
+++ b/src/ui/trip/TripNotesButton.tsx
@@ -1,12 +1,14 @@
+import { TTrip } from '@model/trip.model';
 import Image from 'next/image';
 import Link from 'next/link';
 
-export default function TripNotesButton() {
+type TTripNotesButton = Pick<TTrip, 'id'>;
+
+export default function TripNotesButton({ id }: TTripNotesButton) {
   return (
     <section className="section-box bg-mint-100 p-0">
-      {/* TODO 여행별 노트 페이지로 동적 라우팅 */}
       <Link
-        href={'/note-all-trip'}
+        href={`/note-all-trip/${id}`}
         className="flex w-full items-center justify-between px-6 py-4 text-lg font-bold leading-7"
       >
         <span>

--- a/src/util/calculateDDay.ts
+++ b/src/util/calculateDDay.ts
@@ -1,0 +1,16 @@
+export const calculateDDday = (date: string) => {
+  const today = new Date();
+  const targetDate = new Date(date);
+
+  const diffInMs = targetDate.getTime() - today.getTime();
+
+  const diffInDays = Math.ceil(diffInMs / (1000 * 60 * 60 * 24));
+
+  if (diffInDays > 0) {
+    return `D-${diffInDays}`;
+  } else if (diffInDays === 0) {
+    return 'D-Day';
+  } else {
+    return `D+${Math.abs(diffInDays)}`;
+  }
+};


### PR DESCRIPTION
<!--제목 템플릿-->
<!--[#1] 프로젝트 세팅 v1.0.0-->

# 📝작업 내용
- 여행 정보
  - [x] 여행 정보 조회 API 연동 및 수정 사항 반영(travel -> trip, 변수명 수정)
  - [x] 스켈레톤 컴포넌트 구현 및 api 지연 시 처리
  - [x] D-Day 표시 (현재 날짜로 부터 startDate까지의 날짜 계산)
  - [x] 배경 예시 이미지 제거
  - [ ] 여행 수정하기
  - [x] 여행 삭제하기
    - 여행 삭제 useDeleteTrip 훅 생성
    - 여행 삭제하기 버튼 클릭 시 팝업창 열기 및 메세지 상수화
    - 최종 확인 버튼 클릭 시 삭제 및 메인페이지로 이동
- 여행 노트 모아보기
  - [x] 여행 별 노트 모아보기로 라우팅
# 사용 방법
- Skeleton 컴포넌트는 아래와 같이 정의 할 수 있습니다.
  - className: 스타일 사용자 정의
  - isSquare: 정사각 1:1 비율 유지
  - isCircle: 원형 모양
  
```
'use client';

import Skeleton from '@ui/common/Skeleton';

export default function Playground() {
  return (
    <div>
      <Skeleton className="h-32 w-52" />
    </div>
  );
}

```

https://github.com/user-attachments/assets/bae39b1b-4a11-4499-9adc-d9f0877225b3


# ✨PR Point
> 에러 콘솔 찍어봐야하는데..계속 린트 에러 발생해서 좋은 방법이 없을까요..?ㅠㅠ

> 여행 삭제 후 URL로 직접 입력 후 사용자가 들어왔을 때 없는 페이지라서 라우팅 처리를 해줘야한는데.. 좋은 방법 추천 부탁드립니다 ㅎㅎ