### PR TITLE
[#114] 할일 수정 모달 연결

### DIFF
--- a/src/hooks/task/usePutTask.ts
+++ b/src/hooks/task/usePutTask.ts
@@ -2,7 +2,7 @@ import { putEditTask } from '@lib/api/service/task.api';
 import { TTask } from '@model/task.model';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
-export const usePostTask = () => {
+export const usePutTask = () => {
   const queryClient = useQueryClient();
   const mutation = useMutation({
     mutationFn: async (data: TTask) => {

--- a/src/model/task.model.ts
+++ b/src/model/task.model.ts
@@ -41,7 +41,7 @@ export type TTask = {
   taskDDay?: string;
   taskScope: TTaskScope;
   taskCompletionDate: string;
-  taskAssignees?: string[];
+  taskAssignees?: TTaskAssignee[];
 };
 
 export type TGetTaskDetailRequest = {

--- a/src/model/task.model.ts
+++ b/src/model/task.model.ts
@@ -40,7 +40,7 @@ export type TTask = {
   taskStatus: TTaskStatus;
   taskDDay?: string;
   taskScope: TTaskScope;
-  taskCompletionDate: string;
+  taskCompletionDate?: string;
   taskAssignees?: TTaskAssignee[];
 };
 

--- a/src/ui/card/taskCard/TaskItem.tsx
+++ b/src/ui/card/taskCard/TaskItem.tsx
@@ -10,6 +10,8 @@ import { useDeleteTask } from '@hooks/task/useDeleteTask';
 import { usePopupStore } from '@store/popup.store';
 import { TASK_POPUP_MESSAGE } from '@constant/task';
 import { get } from '@lib/api/axios';
+import { useModalStore } from '@store/modal.store';
+import TodoModal from '@ui/common/TodoModal';
 
 interface ITaskItemProps
   extends Omit<
@@ -31,8 +33,10 @@ function TaskItem({
   taskAssignees,
 }: ITaskItemProps) {
   const deleteTask = useDeleteTask();
+  const editTask = usePutTask();
 
   const { showPopup } = usePopupStore();
+  const { showModal } = useModalStore();
 
   const handleFileClick = () => {
     if (!taskFilePath) {
@@ -72,7 +76,23 @@ function TaskItem({
   };
 
   const handleEditTaskClick = () => {
-    // TODO: 할 일 수정하기
+    showModal({
+      title: '할 일 수정',
+      content: (
+        <TodoModal
+          tripId={tripId}
+          taskId={taskId}
+          taskTitle={taskTitle}
+          taskFilePath={taskFilePath}
+          taskStatus={taskStatus}
+          taskDDay={taskDDay}
+          taskScope={taskScope}
+          taskCompletionDate={taskCompletionDate}
+          taskAssignees={taskAssignees}
+          onConfirm={(data) => editTask.mutate(data)}
+        />
+      ),
+    });
   };
 
   const handleDeleteTaskClick = () => {


### PR DESCRIPTION
<!--제목 템플릿-->
<!--[#1] 프로젝트 세팅 v1.0.0-->

# 📝작업 내용
- usePutTask 훅 네이밍 수정
usePostTask로 되어있어 usePutTask로 훅 네이밍 수정
- 담당자 taskAssignees 타입 수정
담당자 정보 리스트 타입 수정된 API 타입으로 반영
- 할 일 수정 모달 연결
기존 할 일 데이터와 수정 이벤트 핸들러 수정 모달에 전달 및 taskCompletionDate 할 일 완료 타입 옵셔널로 수정
# ✨PR Point
> @JaeHyunGround 님! 기존 할 일에 대한 전체 데이터와 수정 이벤트 핸들러 전달했는데 확인부탁드립니다! 필요한 데이터가 더 있으시면 말씀해주세요~!