### PR TITLE
[#140] 여행 할 일 완료/취소 구현, 할 일 삭제 및 레이아웃 리팩토링

### DIFF
--- a/src/hooks/task/useDeleteTask.ts
+++ b/src/hooks/task/useDeleteTask.ts
@@ -1,3 +1,4 @@
+import { tasksQueryKeys } from '@constant/queryKeyFactory';
 import { deleteTask } from '@lib/api/service/task.api';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
@@ -5,17 +6,20 @@ export const useDeleteTask = () => {
   const queryClient = useQueryClient();
   const mutation = useMutation({
     mutationFn: async (taskId: number) => {
-      await deleteTask(taskId);
-      return taskId;
+      const response = await deleteTask(taskId);
+      return response;
     },
-    onSuccess: (taskId: number) => {
-      // TODO: 삭제 후 데이터 리프레쉬
-      queryClient.invalidateQueries({
-        queryKey: ['tasksList', taskId],
-      });
-      // queryClient.refetchQueries({
-      //   queryKey: ['tasksList', taskId],
-      // });
+    onSuccess: (response) => {
+      if (response.success) {
+        const props = {
+          tripId: response.result.tripId,
+          taskSeq: 0,
+          all: true,
+        };
+        queryClient.invalidateQueries({
+          queryKey: tasksQueryKeys.list(props).queryKey,
+        });
+      }
     },
     onError: (error) => {
       // eslint-disable-next-line no-console

--- a/src/hooks/task/usePutCompleteTask.ts
+++ b/src/hooks/task/usePutCompleteTask.ts
@@ -1,0 +1,32 @@
+import { tasksQueryKeys } from '@constant/queryKeyFactory';
+import { putCompleteTask } from '@lib/api/service/task.api';
+import { TPutCompleteTaskRequest } from '@model/task.model';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+export const usePutCompleteTask = () => {
+  const queryClient = useQueryClient();
+  const mutation = useMutation({
+    mutationFn: async (data: TPutCompleteTaskRequest) => {
+      const response = await putCompleteTask(data);
+      return response;
+    },
+    onSuccess: (response) => {
+      if (response.success) {
+        const props = {
+          tripId: response.result.tripId,
+          taskSeq: 0,
+          all: true,
+        };
+        queryClient.invalidateQueries({
+          queryKey: tasksQueryKeys.list(props).queryKey,
+        });
+      }
+    },
+    onError: (error) => {
+      // eslint-disable-next-line no-console
+      console.error('할일 완료 중 오류 발생:', error);
+    },
+  });
+
+  return mutation;
+};

--- a/src/lib/api/service/task.api.ts
+++ b/src/lib/api/service/task.api.ts
@@ -8,6 +8,8 @@ import {
   TGetTaskRequest,
   TGetTaskResponse,
   TPostAddTaskResponse,
+  TPutCompleteTaskRequest,
+  TPutCompleteTaskResponse,
   TPutEditTaskResponse,
   TTask,
 } from '@model/task.model';
@@ -64,6 +66,13 @@ export const deleteTask = async (taskId: TDeleteTaskRequest) => {
 export const getTaskProgress = async () => {
   const response = await get<TResponse<TGetTaskProgressResponse>>(
     '/api/v1/torip/task/progress',
+  );
+  return response.data;
+};
+
+export const putCompleteTask = async (data: TPutCompleteTaskRequest) => {
+  const response = await put<TResponse<TPutCompleteTaskResponse>>(
+    `/api/v1/torip/task/${data.taskId}?isCompleted=${data.isCompleted}`,
   );
   return response.data;
 };

--- a/src/model/task.model.ts
+++ b/src/model/task.model.ts
@@ -26,6 +26,7 @@ export type TGetTaskResponse = {
   taskStatus: TTaskStatus;
   taskDDay: string;
   taskScope: TTaskScope;
+  isCompleted: boolean;
   taskCompletionDate?: string;
   createdBy: TUserModel;
   createdAt: string;
@@ -43,7 +44,7 @@ export type TUploadTodo = {
   taskDDay?: string;
   taskScope: TTaskScope;
   taskCompletionDate?: string;
-  taskAssignees?: string[];
+  taskAssignees?: TTaskAssignee[];
 };
 
 export type TTask = {
@@ -82,7 +83,7 @@ export type TDeleteTaskRequest = number;
 
 export type TGetTaskDetailRequest = number;
 
-export type TDeleteTaskResponse = number;
+export type TDeleteTaskResponse = { tripId: number };
 
 export type TGetTaskProgressResponse = {
   personalTask: number;
@@ -92,3 +93,7 @@ export type TGetTaskProgressResponse = {
   totalTask: number;
   totalCompletionTask: number;
 };
+
+export type TPutCompleteTaskRequest = { taskId: number; isCompleted: boolean };
+
+export type TPutCompleteTaskResponse = { tripId: number; taskId: number };

--- a/src/ui/card/taskCard/TaskCard.tsx
+++ b/src/ui/card/taskCard/TaskCard.tsx
@@ -23,7 +23,7 @@ export default function TaskCard({
 }: ITaskCardProps) {
   const totalTasks = tasks?.length || 0;
   const completedTasks =
-    tasks?.filter((task) => task.taskCompletionDate)?.length || 0;
+    tasks?.filter((task) => task.isCompleted === true)?.length || 0;
   const progress =
     totalTasks > 0 ? Math.round((completedTasks / totalTasks) * 100) : 0;
 

--- a/src/ui/card/taskCard/TaskItem.tsx
+++ b/src/ui/card/taskCard/TaskItem.tsx
@@ -2,7 +2,7 @@
 
 'use client';
 
-import { memo } from 'react';
+import { memo, useCallback, useEffect, useRef, useState } from 'react';
 import { TGetTaskResponse } from '@model/task.model';
 import CheckBox from '@ui/common/CheckBox';
 import ButtonIconGroup from '@ui/common/ButtonIconGroup';
@@ -14,6 +14,7 @@ import { ScrollShadow } from '@nextui-org/react';
 import { useModalStore } from '@store/modal.store';
 import TodoModal from '@ui/Modal/TodoModal';
 import { usePutTask } from '@hooks/task/usePutTask';
+import { usePutCompleteTask } from '@hooks/task/usePutCompleteTask';
 
 interface ITaskItemProps
   extends Omit<
@@ -27,19 +28,43 @@ function TaskItem({
   tripId,
   taskId,
   taskTitle,
-  taskStatus,
-  createdBy,
-  taskScope,
-  taskCompletionDate,
-  taskDDay,
   taskFilePath,
+  taskStatus,
+  taskDDay,
+  taskScope,
+  isCompleted,
+  taskCompletionDate,
+  createdBy,
   taskAssignees,
 }: ITaskItemProps) {
+  const [isCompletedTask, setIsCompletedTask] = useState(isCompleted || false);
+
   const deleteTask = useDeleteTask();
   const editTask = usePutTask();
+  const putCompleteTask = usePutCompleteTask();
 
   const { showPopup } = usePopupStore();
   const { showModal } = useModalStore();
+
+  const timerRef = useRef<NodeJS.Timeout | null>(null);
+
+  const handleCompleteTaskChange = useCallback(() => {
+    setIsCompletedTask((prev) => {
+      const newCompletedState = !prev;
+
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+      }
+      timerRef.current = setTimeout(() => {
+        putCompleteTask.mutate({
+          taskId: taskId,
+          isCompleted: newCompletedState,
+        });
+      }, 300);
+
+      return newCompletedState;
+    });
+  }, [taskId, putCompleteTask]);
 
   const handleFileClick = () => {
     if (!taskFilePath) {
@@ -115,8 +140,9 @@ function TaskItem({
   return (
     <ScrollShadow>
       <li className="flex items-center justify-between gap-2 transition-colors duration-200 ease-in-out hover:text-primary">
-        {/* TODO: 할 일 체크 */}
-        <CheckBox>{taskTitle}</CheckBox>
+        <CheckBox checked={isCompletedTask} onChange={handleCompleteTaskChange}>
+          {taskTitle}
+        </CheckBox>
         <ButtonIconGroup
           taskAssignees={taskAssignees}
           taskId={taskId}

--- a/src/ui/card/taskCard/TaskList.tsx
+++ b/src/ui/card/taskCard/TaskList.tsx
@@ -15,12 +15,13 @@ export default function TaskList({ tripId, tasks }: ITaskListProps) {
           tripId={tripId ? tripId : 0}
           taskId={task.taskId}
           taskTitle={task.taskTitle}
-          createdBy={task.createdBy}
-          taskStatus={task.taskStatus}
-          taskScope={task.taskScope}
-          taskCompletionDate={task.taskCompletionDate}
-          taskDDay={task.taskDDay}
           taskFilePath={task.taskFilePath}
+          taskStatus={task.taskStatus}
+          taskDDay={task.taskDDay}
+          taskScope={task.taskScope}
+          isCompleted={task.isCompleted}
+          taskCompletionDate={task.taskCompletionDate}
+          createdBy={task.createdBy}
           taskAssignees={task.taskAssignees}
         />
       ))}

--- a/src/ui/common/CheckBox.tsx
+++ b/src/ui/common/CheckBox.tsx
@@ -25,7 +25,7 @@ export default function CheckBox(props: TCheckBoxProps) {
       <label
         htmlFor={uid}
         className={twMerge(
-          'flex-1 cursor-pointer truncate text-sm font-normal leading-tight',
+          'flex-1 cursor-pointer truncate text-sm font-normal leading-tight hover:text-mint-700 active:text-mint-800',
           checked ? 'line-through' : '',
         )}
       >

--- a/src/ui/trip/TripTask.tsx
+++ b/src/ui/trip/TripTask.tsx
@@ -40,17 +40,17 @@ export default function TripTask({ id }: TTripTaskProps) {
   };
 
   return (
-    <div className="section-box flex flex-1 flex-col gap-5">
-      <div className="flex items-center justify-between">
+    <div className="section-box flex flex-1 flex-col gap-5 pr-0">
+      <div className="flex flex-col gap-5 pr-6">
         <h4 className="text-lg font-semibold leading-7 text-slate-800">Todo</h4>
-      </div>
-      <div className="flex items-center justify-between">
-        <FilterButton onClick={handleTaskFilterClick} />
-        <AddTaskButton onClick={handleAddTaskClick} />
+        <div className="flex items-center justify-between">
+          <FilterButton onClick={handleTaskFilterClick} />
+          <AddTaskButton onClick={handleAddTaskClick} />
+        </div>
       </div>
       <TaskCarousel
         tripId={id}
-        tasks={data?.result ? data?.result : []}
+        tasks={data?.success ? data?.result : []}
         height="500px"
       />
     </div>


### PR DESCRIPTION
<!--제목 템플릿-->
<!--[#1] 프로젝트 세팅 v1.0.0-->

# 📝작업 내용
### 1. 할 일 완료/취소 구현
- 사용자가 연속 체크박스 클릭 시 API 호출을 방지하기 위해 디바운스 처리
기존 타이머 참조해서 시간안에 다시 클릭 했을 때 이전 타이머 취소하고 새롭게 실행
- 할 일 hover, action 시 텍스트 색상 변경되도록 수정
- 할 일 taskCompletionDate 데이터로 완료 여부를 정확히 파악하기 어려워 isCompleted를 추가하였습니다.
- TaskItem 컴포넌트 props 순서가 헷갈려서 api 데이터 순서와 동일하게 수정
- 프로그래스바 퍼센트 계산 isCompleted로 계산되도록 변경
- 할 일 완료 API putCompleteTask 함수와 usePutCompleteTask 훅 구현

### 2. 할 일 삭제 성공 시 리스트 반영되도록 API 재호출

### 3. 레이아웃 구조 변경 및 할 일 API 조건 수정
- TripTask 컴포넌트의 레이아웃 구조 개선
- 할 일 API 호출 성공 조건을 `data?.result`에서 `data?.success`로 변경

# 📷스크린샷(필요 시)

https://github.com/user-attachments/assets/4c172921-cc63-4ff8-b4b1-055607a0c219

# ✨PR Point
> 사용자가 연속 체크박스 클릭 시 API 호출을 방지하기 위해 디바운스 처리하였습니다. 기존 타이머 참조해서 시간안에 다시 클릭 했을 때 이전 타이머 취소하고 새롭게 실행해서 API가 연속적으로 호출되지 않도록 했습니다.

> taskCompletionDate 데이터로 할 일 완료 / 취소를 처리할 수 없어 isCompleted를 추가 요청하여 기존 프로그레스바 계산 로직을 수정하였습니다.

> TaskItem 컴포넌트 props 순서가 헷갈려서 api 데이터 순서와 동일하게 수정하였습니다.