### PR TITLE
[#129] Kakao Login

### DIFF
--- a/src/app/(unauthorized)/signin/page.tsx
+++ b/src/app/(unauthorized)/signin/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-// import Image from 'next/image';
+import Image from 'next/image';
 import Link from 'next/link';
 import { SubmitHandler, useForm } from 'react-hook-form';
 import { AUTH_VALIDATION_REGEX } from '@constant/auth';
@@ -9,6 +9,7 @@ import Button from '@ui/common/Button';
 import { INPUT_MESSAGE } from '@constant/input';
 import { useLogin } from '@hooks/auth/useLogin';
 import { useRouter } from 'next/navigation';
+import { signIn } from 'next-auth/react';
 
 type TLoginFormInputs = {
   email: string;
@@ -98,11 +99,11 @@ export default function SignInPage({
           >
             로그인하기
           </Button>
-          {/* TODO: 2차 개발에 추가 */}
-          {/* <Button
+          <Button
             size="large"
             fullWidth={true}
             className="border-[#FEE500] bg-[#FEE500] text-slate-800 hover:border-[#FEE500] hover:bg-[#FEE500] active:border-[#FEE500] active:bg-[#FEE500]"
+            onClick={() => signIn('kakao')}
           >
             <Image
               src="/asset/image/kakao.png"
@@ -111,7 +112,7 @@ export default function SignInPage({
               alt="카카오 아이콘"
             />
             카카오톡으로 로그인하기
-          </Button> */}
+          </Button>
         </div>
         <div className="flex h-5 gap-1">
           <div className="text-sm font-medium leading-tight">

--- a/src/lib/api/service/auth.api.ts
+++ b/src/lib/api/service/auth.api.ts
@@ -1,6 +1,7 @@
 import {
   TGetEmailExistsRequest,
   TGetEmailExistsResponse,
+  TPostKaKaoLoginRequest,
   TPostLoginRequest,
   TPostRefreshTokenRequest,
   TPostRegisterRequest,
@@ -49,4 +50,12 @@ export const getEmailExists = async (data: TGetEmailExistsRequest) => {
     // eslint-disable-next-line no-console
     console.error(err);
   }
+};
+
+export const postKaKaoLogin = async (data: TPostKaKaoLoginRequest) => {
+  const response = await post<TResponse<TTokenResponse | null>>(
+    '/api/v1/torip/auth/kakao/token',
+    data,
+  );
+  return response.data;
 };

--- a/src/lib/authOptions.ts
+++ b/src/lib/authOptions.ts
@@ -1,8 +1,10 @@
 import CredentialsProvider from 'next-auth/providers/credentials';
+import KakaoProvider from 'next-auth/providers/kakao';
 import { NextAuthOptions, Session, User } from 'next-auth';
 import { JWT } from 'next-auth/jwt';
 import dayjs from 'dayjs';
 import {
+  postKaKaoLogin,
   postLogin,
   postRefreshToken,
   postRegister,
@@ -100,11 +102,45 @@ export const authOptions: NextAuthOptions = {
         }
       },
     }),
+    KakaoProvider({
+      clientId: process.env.KAKAO_CLIENT_ID!,
+      clientSecret: process.env.KAKAO_CLIENT_SECRET!,
+    }),
   ],
   pages: {
     signIn: '/signin',
   },
   callbacks: {
+    async signIn({ user, account }) {
+      // 카카오 로그인 서버 검증
+      if (account?.provider === 'kakao' && account.access_token) {
+        try {
+          const {
+            result: token,
+            success,
+            message,
+          } = await postKaKaoLogin({
+            accessToken: account.access_token,
+          });
+          if (success && token) {
+            user.id = token.id.toString();
+            user.name = token.username;
+            user.email = token.email;
+            user.accessToken = token.accessToken;
+            user.refreshToken = token.refreshToken;
+            user.expiredAt = token.expiredAt;
+            return true;
+          } else {
+            throw new Error(message || 'KAKAO Login failed.');
+          }
+        } catch (error) {
+          // eslint-disable-next-line no-console
+          console.error('Error during Kakao login:', error);
+          return false;
+        }
+      }
+      return true;
+    },
     async jwt({ token, user }: { token: JWT; user?: IMyUser }) {
       if (user) {
         token.id = Number(user.id);

--- a/src/lib/authOptions.ts
+++ b/src/lib/authOptions.ts
@@ -37,52 +37,66 @@ export const authOptions: NextAuthOptions = {
           placeholder: '비밀번호를 입력해주세요.',
         },
       },
-      async authorize(
-        credentials: Record<'name' | 'email' | 'password', string> | undefined,
-      ) {
-        // 기존 authorize 함수 내용 유지
+      async authorize(credentials) {
         if (!credentials) {
-          throw new Error('No credentials provided.');
+          return null;
         }
+
         const { name, email, password } = credentials;
 
-        // 회원가입
-        if (name) {
+        try {
+          // 회원가입
+          if (name) {
+            const {
+              result: token,
+              success,
+              message,
+            } = await postRegister({
+              username: name,
+              email: email,
+              password: password,
+            });
+
+            if (success && token) {
+              return {
+                id: token.id.toString(),
+                name: token.username,
+                email: token.email,
+                accessToken: token.accessToken,
+                refreshToken: token.refreshToken,
+                expiredAt: token.expiredAt,
+              };
+            } else {
+              throw new Error(message || 'Signup failed.');
+            }
+          }
+
+          // 로그인
           const {
             result: token,
             success,
             message,
-          } = await postRegister({
-            username: name,
+          } = await postLogin({
             email: email,
             password: password,
           });
 
-          if (success) {
-            return { id: '1', name, email, ...token };
+          if (success && token) {
+            return {
+              id: token.id.toString(),
+              name: token.username,
+              email: token.email,
+              accessToken: token.accessToken,
+              refreshToken: token.refreshToken,
+              expiredAt: token.expiredAt,
+            };
           } else {
-            const error = new Error('Signup failed.');
-            (error as Error).message = message;
-            throw error;
+            throw new Error(message || 'Login failed.');
           }
-        }
-
-        // 로그인
-        const {
-          result: token,
-          success,
-          message,
-        } = await postLogin({
-          email: email,
-          password: password,
-        });
-
-        if (success) {
-          return { id: '1', name, email, ...token };
-        } else {
-          const error = new Error('Login failed.');
-          (error as Error).message = message;
-          throw error;
+        } catch (error) {
+          // eslint-disable-next-line no-console
+          console.error('Authentication error:', error);
+          return null;
         }
       },
     }),

--- a/src/lib/next-auth.d.ts
+++ b/src/lib/next-auth.d.ts
@@ -1,25 +1,21 @@
 // types/next-auth.d.ts
 
-import { DefaultSession } from 'next-auth';
+import { DefaultSession, DefaultUser } from 'next-auth';
 
 declare module 'next-auth' {
   // eslint-disable-next-line @typescript-eslint/naming-convention
   interface Session {
     user: {
       id: number;
-      name: string | null;
-      email: string | null;
     } & DefaultSession['user'];
     accessToken?: string;
     refreshToken?: string;
     expiredAt?: string;
   }
-
-  interface IUser {
-    id: number;
-    name: string;
-    email: string;
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  interface User extends DefaultUser {
     accessToken?: string;
     refreshToken?: string;
+    expiredAt?: string;
   }
 }

--- a/src/model/auth.model.ts
+++ b/src/model/auth.model.ts
@@ -13,3 +13,7 @@ export type TGetEmailExistsRequest = string;
 export type TGetEmailExistsResponse = {
   exists: boolean;
 };
+
+export type TPostKaKaoLoginRequest = {
+  accessToken: string;
+};

--- a/src/model/model.ts
+++ b/src/model/model.ts
@@ -6,6 +6,9 @@ export type TResponse<T> = {
 };
 
 export type TTokenResponse = {
+  id: number;
+  username: string;
+  email: string;
   accessToken: string;
   refreshToken: string;
   expiredAt: string;


### PR DESCRIPTION
<!--제목 템플릿-->
<!--[#1] 프로젝트 세팅 v1.0.0-->

# 📝작업 내용
- [x] 카카오 Developers 앱 생성 및 Client Secret 생성
- [x] 도메인과 Redirect URL 등록
- [x] env 카카오 관련 키 추가 (노션에 작성해뒀습니다.)
- [x] 카카오 로그인 버튼에 signIn('kakao') 핸들러 추가
- [x] KakaoProvider 추가로 카카오 로그인 지원
  - `clientId`와 `clientSecret` 환경 변수 적용
- [x] 카카오 로그인 후 인증 받고 토근 백엔드에 전달하며 로그인 요청
   - 카카오 로그인 API 함수 및 타입 정의
   - 카카오 로그인 시 서버 검증 로직 추가 (`postKaKaoLogin`)
   - next-auth 타입 정의 수정 및 확장
   - 성공 시 사용자 정보 매핑



# ✨PR Point
### kakao Login 로직 추가 외 기존 코드 변경 사항
> 카카오 로그인에서도 동일하게 필요해서 변경된 로그인 API Response 타입 반영하였습니다. 
```
export type TTokenResponse = {
  id: number;
  username: string;
  email: string;
  accessToken: string;
  refreshToken: string;
  expiredAt: string;
};
```


> 타입을 변경하면서 authorize 에러 발생하여 해결하였습니다.
```
'(credentials: Record<"name" | "email" | "password", string> | undefined) => Promise<{ id: string | undefined; name: string | undefined; email: string | undefined; accessToken: string | undefined; refreshToken: string | undefined; expiredAt: string | undefined; } | null>' 형식은 '(credentials: Record<"name" | "email" | "password", string> | undefined, req: Pick<RequestInternal, "body" | "query" | "headers" | "method">) => Awaitable<...>' 형식에 할당할 수 없습니다. 
'Promise<{ id: string | undefined; name: string | undefined; email: string | undefined; accessToken: string | undefined; refreshToken: string | undefined; expiredAt: string | undefined; } | null>' 형식은 'Awaitable<User | null>' 형식에 할당할 수 없습니다. 
'Promise<{ id: string | undefined; name: string | undefined; email: string | undefined; accessToken: string | undefined; refreshToken: string | undefined; expiredAt: string | undefined; } | null>' 형식은 'PromiseLike<User | null>' 형식에 할당할 수 없습니다. 
'then' 속성의 형식이 호환되지 않습니다. 
'<TResult1 = { id: string | undefined; name: string | undefined; email: string | undefined; accessToken: string | undefined; refreshToken: string | undefined; expiredAt: string | undefined; } | null, TResult2 = never>(onfulfilled?: ((value: { ...; } | null) => TResult1 | PromiseLike<...>) | ... 1 more ... | undefined...' 형식은 '<TResult1 = User | null, TResult2 = never>(onfulfilled?: ((value: User | null) => TResult1 | PromiseLike<TResult1>) | null | undefined, onrejected?: ((reason: any) => TResult2 | PromiseLike<...>) | null | undefined) => PromiseLike<...>' 형식에 할당할 수 없습니다. 
'onfulfilled' 및 'onfulfilled' 매개 변수의 형식이 호환되지 않습니다. 
'value' 및 'value' 매개 변수의 형식이 호환되지 않습니다. 
'{ id: string | undefined; name: string | undefined; email: string | undefined; accessToken: string | undefined; refreshToken: string | undefined; expiredAt: string | undefined; } | null' 형식은 'User | null' 형식에 할당할 수 없습니다. 
'{ id: string | undefined; name: string | undefined; email: string | undefined; accessToken: string | undefined; refreshToken: string | undefined; expiredAt: string | undefined; }' 형식은 'User' 형식에 할당할 수 없습니다. 'id' 속성의 형식이 호환되지 않습니다.
 'string | undefined' 형식은 'string' 형식에 할당할 수 없습니다. 
 'undefined' 형식은 'string' 형식에 할당할 수 없습니다.ts(2322) credentials.d.ts(13, 5): 필요한 형식은 여기에서 'UserCredentialsConfig<{ name: { label: string; type: string; placeholder: string; }; email: { label: string; type: string; placeholder: string; }; password: { label: string; type: string; placeholder: string; }; }>' 형식에 선언된 'authorize' 속성에서 가져옵니다. 
 (property) authorize: (credentials: Record<"name" | "email" | "password", string> | undefined, req: Pick<RequestInternal, "body" | "query" | "headers" | "method">) => Awaitable<User | null>
```
credentials 없거나 API 호출 실패 시 null 값을 반환하도록 수정하였습니다. 


> api 호출 에러를 파악하기 어려워 `try-catch`로 감싸 에러 핸들링을 추가하였습니다. authorize함수에서 기존 로그인 폼에서 전달된 데이터로 id, name, email을 반환하고 있어, 로그인/회원가입 API 호출 성공 시 응답값을 활용하여 데이터를 반환하도록 수정하였습니다. 또한, API 호출의 success 값이 false일 때 에러 로그 출력 코드를 한 줄로 간소화하였습니다.


> User 타입을 확장 했으며, interface 코드컨벤션이 앞에 `I`를 명시해줘야하는데 Next auth에서 User 타입을 찾지 못해 제거하였고, lint 무시 처리 하였습니다. 
```
  // eslint-disable-next-line @typescript-eslint/naming-convention
  interface User extends DefaultUser {
    accessToken?: string;
    refreshToken?: string;
    expiredAt?: string;
  }
```


> 기존 Session 타입을 확장했는데 DefaultSession['user']에 이미 포함된 name, email 중복되어 제거하였습니다.

> 궁금하신 부분은 말씀해 주세요! 자세히 설명 드리겠습니다.