### PR TITLE
[#187] 여행 정보 드롭다운 메뉴 에러 해결 및 테스트

### DIFF
--- a/src/test/common/DropdownMenu.test.tsx
+++ b/src/test/common/DropdownMenu.test.tsx
@@ -1,0 +1,70 @@
+import { render, waitFor, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import DropdownMenu from '@ui/common/DropdownMenu';
+import userEvent from '@testing-library/user-event';
+
+describe('DropdownMenu Component', () => {
+  const onMenuClick = jest.fn();
+  const items = [
+    { label: 'option1', onClick: onMenuClick },
+    { label: 'option2', onClick: onMenuClick, disabled: true },
+  ];
+
+  test('should render correctly', () => {
+    const wrapper = render(<DropdownMenu items={items}>menu</DropdownMenu>);
+    expect(() => wrapper.unmount()).not.toThrow();
+  });
+
+  test('should contain a button', () => {
+    const { getByRole } = render(
+      <DropdownMenu items={items}>menu</DropdownMenu>,
+    );
+
+    const menuButton = getByRole('button', { name: /menu/i });
+    expect(menuButton).not.toBeNull();
+  });
+
+  test('should open the menu when button is clicked', async () => {
+    const { getByRole } = render(
+      <DropdownMenu items={items}>menu</DropdownMenu>,
+    );
+
+    const menuButton = getByRole('button', { name: /menu/i });
+    expect(menuButton).toHaveAttribute('aria-expanded', 'false');
+    expect(screen.queryByText(/option1/i)).toBeNull();
+
+    await userEvent.click(menuButton);
+
+    await waitFor(() => {
+      expect(menuButton).toHaveAttribute('aria-expanded', 'true');
+      expect(screen.getByText(/option1/i)).toBeInTheDocument();
+      expect(screen.getByText(/option2/i)).toBeInTheDocument();
+    });
+  });
+
+  test('should call onClick event when menu item is clicked', async () => {
+    const { getByRole } = render(
+      <DropdownMenu items={items}>menu</DropdownMenu>,
+    );
+
+    const menuButton = getByRole('button', { name: /menu/i });
+    await userEvent.click(menuButton);
+
+    const option1 = await screen.findByText('option1');
+    fireEvent.click(option1);
+
+    expect(onMenuClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('should have aria-disabled attribute for disabled menu item', async () => {
+    const { getByRole } = render(
+      <DropdownMenu items={items}>menu</DropdownMenu>,
+    );
+
+    const menuButton = getByRole('button', { name: /menu/i });
+    await userEvent.click(menuButton);
+
+    const disabledItem = await screen.findByText('option2');
+    expect(disabledItem).toHaveAttribute('aria-disabled', 'true'); // Radix UI 스타일 확인
+  });
+});

--- a/src/ui/trip/TripInfo.tsx
+++ b/src/ui/trip/TripInfo.tsx
@@ -106,7 +106,7 @@ export default function TripInfo({ id }: TTripInfoProps) {
         } as React.CSSProperties
       }
       className={twMerge(
-        'section-box relative min-h-[136px] overflow-hidden bg-cover bg-center bg-no-repeat',
+        'section-box relative flex min-h-[136px] flex-row justify-between overflow-hidden bg-cover bg-center bg-no-repeat',
         // 'before:to--[#888888]/30 before:absolute before:inset-0 before:bg-gradient-to-r before:from-black before:opacity-50 before:content-[""]',
         // 'bg-[image:var(--bg-img)]',
         // backgroundImage && 'bg-[image:var(--bg-img)]',
@@ -118,7 +118,7 @@ export default function TripInfo({ id }: TTripInfoProps) {
         </h3>
         <div className="text-[2rem] font-black leading-none">{dDay}</div>
       </div>
-      <div className="absolute right-4 top-4">
+      <div>
         <DropdownMenu
           items={[
             { label: '공유하기', onClick: handleCopyInviteLink },
@@ -130,7 +130,6 @@ export default function TripInfo({ id }: TTripInfoProps) {
                 ]
               : []),
           ]}
-          className="bg-transparent font-black"
         >
           <Image
             src="/asset/icon/kebab.png"


### PR DESCRIPTION
<!--제목 템플릿-->
<!--[#1] 프로젝트 세팅 v1.0.0-->

# 📝작업 내용
- 여행 정보 드롭다운 메뉴 버튼 중앙이 안눌리는 에러 해결
- 드롭다운 컴포넌트 유닛 테스트

# ✨PR Point
> 일단 absolute를 주고 좌/우 값을 지정해주면 안에 트리거 클릭 영역이 줄어드는 것 같습니다 ㅠㅠ 흠.. 일단 background 넣었을 때 영역은 잘 잡히는데 트리거 영역을 파악하기 어렵네요 ㅠㅠ absolute 사용 안하고 레이아웃 잡아서 수정했습니다.

> 드롭다운 컴포넌트 테스트 진행했는데 shadcn UI를 사용하다보니 비활성화 상태를 aria-disabled 속성으로 체크하고 있는 것 같아 테스트에서 드롭다운 안에 메뉴 버튼 클릭 비활성화를 판단하기에는 어렵고 aria-disabled 속성이 true인지로 체크하여 테스트 진행했습니다.

