### PR TITLE
[#192] 서버 props 대신 useSearchParams 사용하여 클라이언트 컴포넌트 수정

### DIFF
--- a/src/app/(unauthorized)/signin/page.tsx
+++ b/src/app/(unauthorized)/signin/page.tsx
@@ -8,7 +8,7 @@ import AuthInput from '@ui/auth/AuthInput';
 import Button from '@ui/common/Button';
 import { INPUT_MESSAGE } from '@constant/input';
 import { useLogin } from '@hooks/auth/useLogin';
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { signIn } from 'next-auth/react';
 
 type TLoginFormInputs = {
@@ -16,11 +16,7 @@ type TLoginFormInputs = {
   password: string;
 };
 
-export default function SignInPage({
-  searchParams,
-}: {
-  searchParams: { redirectTo?: string };
-}) {
+export default function SignInPage() {
   const {
     register,
     formState: { errors, isValid },
@@ -28,16 +24,15 @@ export default function SignInPage({
     setError,
   } = useForm<TLoginFormInputs>({ mode: 'onBlur' });
   const { loginHandler } = useLogin();
+
+  const searchParams = useSearchParams();
+  const redirectTo = searchParams.get('redirectTo');
   const router = useRouter();
 
   const onSubmit: SubmitHandler<TLoginFormInputs> = async (data) => {
     const res = await loginHandler('credentials', { ...data, redirect: false });
     if (res?.ok) {
-      if (searchParams.redirectTo) {
-        router.push(searchParams.redirectTo);
-      } else {
-        router.push('/');
-      }
+      router.push(redirectTo ? redirectTo : '/');
     } else if (res) {
       // 에러 메시지에 따라 필드별로 에러 설정
       if (res?.error === '비밀번호가 일치하지 않습니다.') {
@@ -120,8 +115,8 @@ export default function SignInPage({
           </div>
           <Link
             href={
-              searchParams.redirectTo
-                ? `/signup?redirectTo=${encodeURIComponent(searchParams.redirectTo)}`
+              redirectTo
+                ? `/signup?redirectTo=${encodeURIComponent(redirectTo)}`
                 : '/signup'
             }
             className="text-sm font-medium leading-tight text-mint-500 underline"

--- a/src/app/(unauthorized)/signup/page.tsx
+++ b/src/app/(unauthorized)/signup/page.tsx
@@ -6,7 +6,7 @@ import Button from '@ui/common/Button';
 import { AUTH_VALIDATION_REGEX } from '@constant/auth';
 import Link from 'next/link';
 import { useLogin } from '@hooks/auth/useLogin';
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { getEmailExists } from '@lib/api/service/auth.api';
 
 interface ISignUpFormInputs {
@@ -15,11 +15,7 @@ interface ISignUpFormInputs {
   password: string;
   passwordConfirm: string;
 }
-export default function SignUpPage({
-  searchParams,
-}: {
-  searchParams: { redirectTo?: string };
-}) {
+export default function SignUpPage() {
   const {
     register,
     handleSubmit,
@@ -27,6 +23,10 @@ export default function SignUpPage({
     formState: { errors, isValid },
   } = useForm<ISignUpFormInputs>({ mode: 'onBlur' });
   const { loginHandler } = useLogin();
+
+  const searchParams = useSearchParams();
+  const redirectTo = searchParams.get('redirectTo');
+
   const router = useRouter();
 
   // 이메일 중복 체크 함수
@@ -44,11 +44,7 @@ export default function SignUpPage({
       redirect: false,
     });
     if (res?.ok) {
-      if (searchParams.redirectTo) {
-        router.push(searchParams.redirectTo);
-      } else {
-        router.push('/');
-      }
+      router.push(redirectTo ? redirectTo : '/');
     }
   };
 
@@ -130,7 +126,14 @@ export default function SignUpPage({
 
       <div className="flex justify-center gap-1 text-sm font-medium text-slate-800">
         <p>이미 회원이신가요? </p>
-        <Link href={'/signin'} className="text-mint-500 underline">
+        <Link
+          href={
+            redirectTo
+              ? `/signin?redirectTo=${encodeURIComponent(redirectTo)}`
+              : '/signin'
+          }
+          className="text-mint-500 underline"
+        >
           로그인
         </Link>
       </div>


### PR DESCRIPTION
<!--제목 템플릿-->
<!--[#1] 프로젝트 세팅 v1.0.0-->

# 📝작업 내용
서버 props 대신 useSearchParams 사용하여 클라이언트 컴포넌트 수정

# ✨PR Point
배포 서비스에서 로그인 성공 후 대시보드로 리다이렉트 되어야하는데 타입에러가 발생하였습니다.
searchParams.redirectTo에서 문자열이 아니라 null이나 undefined로 들어와서 에러가 발생한게 아닐까 싶습니다. 
로그인 컴포넌트 확인해보니 클라이언트 컴포넌트인데 서버 props로 searchParams를 가져오고 있더라고요..ㅠㅠuseSearchParams로 수정했습니다. 로컬에서는 문제 없는데 배포 후 에러 확인이 필요할 것 같습니다.